### PR TITLE
feat: Use named targetPort http in Service definition

### DIFF
--- a/charts/pyrra/templates/service.yaml
+++ b/charts/pyrra/templates/service.yaml
@@ -18,6 +18,7 @@ spec:
       port: 9444
     - name: http
       port: {{ .Values.service.port }}
+      targetPort: http
       {{- if .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}


### PR DESCRIPTION
Title: Use named targetPort 'http' in Service definition

Description:
This PR changes the Kubernetes Service to explicitly use `targetPort: http`.
This aligns with the container port name, improves portability, and avoids relying on default resolution logic.