### PR TITLE
Expose `configMapMode` CLI flag

### DIFF
--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.15.0
+version: 0.15.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -21,6 +21,7 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | additionalLabels | object | `{}` |  |
+| configMapMode.enabled | bool | `false` | enables configMap mode to generate the PrometheusRules in a configMap |
 | dashboards.annotations | object | `{}` |  |
 | dashboards.enabled | bool | `false` | enables Grafana dashboards being deployed via configmap |
 | dashboards.extraLabels | object | `{}` |  |

--- a/charts/pyrra/templates/clusterrole.yaml
+++ b/charts/pyrra/templates/clusterrole.yaml
@@ -44,3 +44,16 @@ rules:
   - get
   - patch
   - update
+{{- if .Values.configMapMode.enabled }}
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+  - list
+  - watch
+  - update
+  - delete
+{{- end }}

--- a/charts/pyrra/templates/deployment.yaml
+++ b/charts/pyrra/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
             {{- if .Values.genericRules.enabled }}
             - --generic-rules
             {{- end }}
+            {{- if .Values.configMapMode.enabled }}
+            - --config-map-mode
+            {{- end }}
             {{- if and .Values.validatingWebhookConfiguration.enabled ($.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
             - --disable-webhooks=false
             {{- end }}

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -140,6 +140,10 @@ genericRules:
   # -- enables generate Pyrra generic recording rules. Pyrra generates metrics with the same name for each SLO.
   enabled: false
 
+configMapMode:
+  # -- enables configMap mode to generate the PrometheusRules in a configMap
+  enabled: false
+
 validatingWebhookConfiguration:
   # -- enables admission webhook for server to validate SLOs, this requires cert-manager to be installed
   enabled: false


### PR DESCRIPTION
This PR exposes the `config-map-mode` cli flag via the values including the required ClusterRole modifications.

**Motivation**
We use cortex to read PrometheusRules via ConfigMaps. Pyrra itself does support that, but the helm chart does not (yet).

