### PR TITLE
fix: apply additionalLabels also to podSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ Each chart documentation is available in the [charts directory](https://github.c
 
 ## Contributing
 
-If you changed the Helm values, please run [helm-docs](https://github.com/norwoodj/helm-docs) in charts/pyrra folder to re-generate the README accordingly.
+If you changed the Helm values, please run [helm-docs](https://github.com/norwoodj/helm-docs) in charts/pyrra folder to re-generate the readme accordingly.
 Alternatively you can use the provided [pre-commit](https://pre-commit.com/) hooks.

--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ Each chart documentation is available in the [charts directory](https://github.c
 
 ## Contributing
 
-If you changed the Helm values, please run [helm-docs](https://github.com/norwoodj/helm-docs) in charts/pyrra folder to re-generate the readme accordingly.
+If you changed the Helm values, please run [helm-docs](https://github.com/norwoodj/helm-docs) in charts/pyrra folder to re-generate the README accordingly.
 Alternatively you can use the provided [pre-commit](https://pre-commit.com/) hooks.

--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pyrra
 # renovate: github=pyrra-dev/pyrra
 appVersion: v0.9.5
-version: 1.3.1
+version: 1.4.0
 description: SLO manager and alert generator
 sources:
   - https://github.com/pyrra-dev/pyrra

--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pyrra
 # renovate: github=pyrra-dev/pyrra
 appVersion: v0.9.5
-version: 1.3.0
+version: 1.3.1
 description: SLO manager and alert generator
 sources:
   - https://github.com/pyrra-dev/pyrra

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -33,7 +33,7 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| additionalLabels | object | `{}` |  |
+| additionalLabels | object | `{}` | Extra labels to add to the deploymentSpec and podSpec |
 | dashboards.annotations | object | `{}` |  |
 | dashboards.enabled | bool | `false` | enables Grafana dashboards being deployed via configmap |
 | dashboards.extraLabels | object | `{}` |  |

--- a/charts/pyrra/templates/deployment.yaml
+++ b/charts/pyrra/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       {{- end }}
       labels:
         {{- include "pyrra.selectorLabels" . | nindent 8 }}
+        {{- with .Values.additionalLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -15,6 +15,7 @@ image:
   # -- Overrides the image tag
   tag: ""
 
+# -- Extra labels to add to the deploymentSpec and podSpec
 additionalLabels: {}
   # app: pyrra
 


### PR DESCRIPTION
This patch adds the `additionalLabels` to the podSpec, not just the deploymentSpec. I believe that this approach is the most backwards friendly approach.

I checked how other charts use it and it's really a mixed approach. Some have global "labels" and specific "podLabels". Some have "extraLabels" and apply them to all resources.

Solves #21 