### PR TITLE
build(renovate): use 'prometheus-community/helm-charts' configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,6 @@
   commitBody: 'Signed-off-by: Pyrra renovatebot <renoavte@pyrra.dev>',
   extends: [
     'config:recommended',
-    'customManagers:helmChartYamlAppVersions'
+    'github>prometheus-community/helm-charts//renovate.json',
   ],
 }

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -8,48 +8,60 @@ jobs:
     strategy:
       matrix:
         k8s-version:
-          - "kindest/node:v1.29.14"
-          - "kindest/node:v1.30.10"
-          - "kindest/node:v1.31.6"
-          - "kindest/node:v1.32.3"
+          - "kindest/node:v1.31.12"
+          - "kindest/node:v1.32.8"
+          - "kindest/node:v1.33.4"
+          - "kindest/node:v1.34.0"
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
-          version: v3.17.3
+          # renovate: github=helm/helm
+          version: v3.19.0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: 3.14.0
+          python-version: '3.13'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.7.0
+        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
+        with:
+          # renovate: github=helm/chart-testing
+          version: v3.14.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
           changed=$(ct list-changed --config ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "changed_list=\"${changed//$'\n'/ }\"" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --config ct.yaml --check-version-increment=false --validate-maintainers=false --validate-yaml=false
+        run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
           node_image: ${{ matrix.k8s-version }}
 
-      - name: Install prometheus-operator-crds
+      - name: Apply Gateway API CRDs
         run: |
-          helm install --repo https://prometheus-community.github.io/helm-charts prometheus-operator-crds prometheus-operator-crds
+          kubectl apply -k https://github.com/kubernetes-sigs/gateway-api/config/crd
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Apply Prometheus Operator CRDs
+        env:
+          CHANGED_LIST: ${{ steps.list-changed.outputs.changed_list }}
+        run: |
+          helm install prometheus-operator-crds oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -1,25 +1,9 @@
 apiVersion: v2
 name: pyrra
-description: SLO manager and alert generator
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
-type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-
-version: 0.15.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
+# renovate: github=pyrra-dev/pyrra
 appVersion: v0.8.1
+version: 0.15.1
+description: SLO manager and alert generator
+sources:
+  - https://github.com/pyrra-dev/pyrra
+type: application

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -1,8 +1,12 @@
 # pyrra
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
+![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
 
 SLO manager and alert generator
+
+## Source Code
+
+* <https://github.com/pyrra-dev/pyrra>
 
 ## Prometheus settings
 Pyrra needs prometheus to work. You will need to specify that via prometheusUrl variable - default assumes you have default [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) deployed to "monitoring" namespace.
@@ -33,7 +37,7 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | genericRules.enabled | bool | `false` | enables generate Pyrra generic recording rules. Pyrra generates metrics with the same name for each SLO. |
 | image.pullPolicy | string | `"IfNotPresent"` | Overrides pullpolicy |
 | image.repository | string | `"ghcr.io/pyrra-dev/pyrra"` | Overrides the image repository |
-| image.tag | string | `"v0.8.1"` | Overrides the image tag |
+| image.tag | string | `""` | Overrides the image tag |
 | imagePullSecrets | list | `[]` | specifies pull secrets for image repository |
 | ingress.annotations | object | `{}` | additional annotations for ingress |
 | ingress.className | string | `""` | specifies ingress class name (ie nginx) |

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- Overrides pullpolicy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag
-  tag: "v0.8.1"
+  tag: ""
 
 additionalLabels: {}
   # app: pyrra

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,8 +1,8 @@
+# See https://github.com/helm/chart-testing#configuration
 remote: origin
 target-branch: main
 chart-dirs:
   - charts
-chart-repos:
-  - bitnami=https://charts.bitnami.com/bitnami
 helm-extra-args: --timeout 600s
+use-helmignore: true
 validate-maintainers: false


### PR DESCRIPTION
- `image.tag` was removed in order to use the version from Chart.yaml by default
- update `lint-test`
- cleanup ct config