### PR TITLE
chore: fix broken charts link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-```
+```bash
 helm repo add pyrra https://pyrra-dev.github.io/helm-charts
 ```
 
@@ -10,5 +10,5 @@ Each chart documentation is available in the [charts directory](https://github.c
 
 ## Contributing
 
-If you changed the Helm values, please run [helm-docs](https://github.com/norwoodj/helm-docs) in charts/pyrra folder to re-generate the README accordingly.
+If you changed the Helm values, please run [helm-docs](https://github.com/norwoodj/helm-docs) in charts/pyrra folder to re-generate the readme accordingly.
 Alternativly you can use the provided [pre-commit](https://pre-commit.com/) hooks.


### PR DESCRIPTION
Fixes broken link in README to point to the `charts` directory