### PR TITLE
feat: add leader election support and fix namespace in resource metadata

### DIFF
--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pyrra
 # renovate: github=pyrra-dev/pyrra
 appVersion: v0.10.0
-version: 1.4.0
+version: 1.5.0
 description: SLO manager and alert generator
 sources:
   - https://github.com/pyrra-dev/pyrra

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -60,7 +60,9 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | nameOverride | string | `""` | overrides chart name |
 | namespaceOverride | string | `""` | Overrides the namespace for all resources (defaults to .Release.Namespace) |
 | nodeSelector | object | `{}` | node selector for scheduling server pod |
-| operator | object | `{"resources":{"limits":{"memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}}` | All settings related to the "operator" kubernetes container |
+| operator | object | `{"leaderElection":{"enabled":true,"namespace":""},"resources":{"limits":{"memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}}` | All settings related to the "operator" kubernetes container |
+| operator.leaderElection.enabled | bool | `true` | enables leader election for the operator (required when running multiple replicas) |
+| operator.leaderElection.namespace | string | `""` | namespace where the leader election lease resource will be created (defaults to release namespace) |
 | operator.resources | object | `{"limits":{"memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}` | resource limits and requests |
 | operatorMetricsAddress | string | `":8080"` | Address to expose operator metrics |
 | podAnnotations | object | `{}` | additional annotations for server pod |

--- a/charts/pyrra/templates/clusterrole.yaml
+++ b/charts/pyrra/templates/clusterrole.yaml
@@ -44,3 +44,17 @@ rules:
   - get
   - patch
   - update
+{{- if .Values.operator.leaderElection.enabled }}
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{- end }}

--- a/charts/pyrra/templates/deployment.yaml
+++ b/charts/pyrra/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "pyrra.fullname" . }}
+  namespace: {{ include "pyrra.namespace" . }}
   labels:
     {{- include "pyrra.labels" . | nindent 4 }}
 spec:
@@ -41,6 +42,10 @@ spec:
             {{- end }}
             {{- if .Values.operatorMetricsAddress }}
             - --metrics-addr={{ .Values.operatorMetricsAddress }}
+            {{- end }}
+            {{- if .Values.operator.leaderElection.enabled }}
+            - --enable-leader-election
+            - --leader-election-namespace={{ .Values.operator.leaderElection.namespace | default (include "pyrra.namespace" .) }}
             {{- end }}
             {{- with .Values.extraKubernetesArgs }}
             {{- toYaml . | nindent 12 }}

--- a/charts/pyrra/templates/ingress.yaml
+++ b/charts/pyrra/templates/ingress.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "pyrra.fullname" . }}
+  namespace: {{ include "pyrra.namespace" . }}
   labels:
     {{- include "pyrra.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/pyrra/templates/prometheusrule.yaml
+++ b/charts/pyrra/templates/prometheusrule.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "pyrra.fullname" . }}-prometheusrule
+  namespace: {{ include "pyrra.namespace" . }}
   labels:
     {{- include "pyrra.labels" . | nindent 4 }}
 spec:

--- a/charts/pyrra/templates/service.yaml
+++ b/charts/pyrra/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "pyrra.fullname" . }}
+  namespace: {{ include "pyrra.namespace" . }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/pyrra/templates/serviceaccount.yaml
+++ b/charts/pyrra/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "pyrra.serviceAccountName" . }}
+  namespace: {{ include "pyrra.namespace" . }}
   labels:
     {{- include "pyrra.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/pyrra/templates/servicemonitor-operator.yaml
+++ b/charts/pyrra/templates/servicemonitor-operator.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "pyrra.fullname" . }}-operator
+  namespace: {{ include "pyrra.namespace" . }}
   labels:
     {{- include "pyrra.labels" . | nindent 4 }}
     {{- if .Values.serviceMonitorOperator.labels }}

--- a/charts/pyrra/templates/servicemonitor-server.yaml
+++ b/charts/pyrra/templates/servicemonitor-server.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "pyrra.fullname" . }}-server
+  namespace: {{ include "pyrra.namespace" . }}
   labels:
     {{- include "pyrra.labels" . | nindent 4 }}
     {{- if .Values.serviceMonitor.labels }}

--- a/charts/pyrra/templates/validatingwebhookconfiguration.yaml
+++ b/charts/pyrra/templates/validatingwebhookconfiguration.yaml
@@ -4,6 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "pyrra.fullname" . }}-selfsigned
+  namespace: {{ include "pyrra.namespace" . }}
 spec:
   selfSigned: {}
 ---
@@ -11,6 +12,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "pyrra.fullname" . }}-webhook-validation
+  namespace: {{ include "pyrra.namespace" . }}
 spec:
   dnsNames:
   -  {{ include "pyrra.fullname" . }}.{{ include "pyrra.namespace" . }}.svc

--- a/charts/pyrra/tests/clusterrole_test.yaml
+++ b/charts/pyrra/tests/clusterrole_test.yaml
@@ -1,0 +1,48 @@
+suite: clusterrole
+templates:
+  - templates/clusterrole.yaml
+tests:
+  - it: should render one ClusterRole by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+
+  - it: should include leases rule when leaderElection is enabled
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - coordination.k8s.io
+            resources:
+              - leases
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+
+  - it: should not include leases rule when leaderElection is disabled
+    set:
+      operator.leaderElection.enabled: false
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - coordination.k8s.io
+            resources:
+              - leases
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch

--- a/charts/pyrra/tests/deployment_test.yaml
+++ b/charts/pyrra/tests/deployment_test.yaml
@@ -71,3 +71,33 @@ tests:
           content:
             name: test-volume
             mountPath: /test
+
+  - it: should include --enable-leader-election arg by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-leader-election
+
+  - it: should include --leader-election-namespace arg with release namespace by default
+    release:
+      namespace: observability
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-election-namespace=observability
+
+  - it: should not include --enable-leader-election arg when leaderElection is disabled
+    set:
+      operator.leaderElection.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-leader-election
+
+  - it: should use custom namespace for leader election when set
+    set:
+      operator.leaderElection.namespace: monitoring
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-election-namespace=monitoring

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -152,6 +152,11 @@ operator:
     requests:
       cpu: 10m
       memory: 128Mi
+  leaderElection:
+    # -- enables leader election for the operator (required when running multiple replicas)
+    enabled: true
+    # -- namespace where the leader election lease resource will be created (defaults to release namespace)
+    namespace: ""
 
 # -- node selector for scheduling server pod
 nodeSelector: {}


### PR DESCRIPTION
Add operator.leaderElection with enabled (default: true) and namespace fields, pass --enable-leader-election/--leader-election-namespace to the kubernetes container, add coordination.k8s.io/leases RBAC rules to ClusterRole, fix missing namespace metadata on all namespace-scoped resources, and add helm unit tests for leader election.