### PR TITLE
refactor(chart): extract container definitions into _pod.tpl

### DIFF
--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pyrra
 # renovate: github=pyrra-dev/pyrra
 appVersion: v0.10.0
-version: 1.5.0
+version: 1.6.0
 description: SLO manager and alert generator
 sources:
   - https://github.com/pyrra-dev/pyrra

--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pyrra
 # renovate: github=pyrra-dev/pyrra
 appVersion: v0.10.0
-version: 1.6.0
+version: 1.7.0
 description: SLO manager and alert generator
 sources:
   - https://github.com/pyrra-dev/pyrra

--- a/charts/pyrra/templates/_pod.tpl
+++ b/charts/pyrra/templates/_pod.tpl
@@ -1,0 +1,75 @@
+{{/*
+Container definition for the Pyrra operator (kubernetes mode).
+*/}}
+{{- define "pyrra.container.kubernetes" -}}
+- name: {{ .Chart.Name }}-kubernetes
+  securityContext:
+    {{- toYaml .Values.securityContext | nindent 4 }}
+  image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  args:
+    - kubernetes
+    {{- if .Values.genericRules.enabled }}
+    - --generic-rules
+    {{- end }}
+    {{- if and .Values.validatingWebhookConfiguration.enabled ($.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
+    - --disable-webhooks=false
+    {{- end }}
+    {{- if .Values.operatorMetricsAddress }}
+    - --metrics-addr={{ .Values.operatorMetricsAddress }}
+    {{- end }}
+    {{- if .Values.operator.leaderElection.enabled }}
+    - --enable-leader-election
+    - --leader-election-namespace={{ .Values.operator.leaderElection.namespace | default (include "pyrra.namespace" .) }}
+    {{- end }}
+    {{- with .Values.extraKubernetesArgs }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  resources:
+    {{- toYaml .Values.operator.resources | nindent 4 }}
+  {{- if and .Values.validatingWebhookConfiguration.enabled ($.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
+  volumeMounts:
+    - mountPath: /tmp/k8s-webhook-server/serving-certs
+      name: certs
+  {{- end }}
+  ports:
+    - name: op-metrics
+      containerPort: {{ include "pyrra.operatorMetricsPort" . }}
+    - name: webhooks
+      containerPort: 9443
+{{- end }}
+
+{{/*
+Container definition for the Pyrra API server.
+*/}}
+{{- define "pyrra.container.api" -}}
+- name: {{ .Chart.Name }}
+  securityContext:
+    {{- toYaml .Values.securityContext | nindent 4 }}
+  image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  args:
+    - api
+    - --prometheus-url={{ .Values.prometheusUrl }}
+    - --api-url=http://localhost:9444
+    {{- if .Values.prometheusExternalUrl }}
+    - --prometheus-external-url={{ .Values.prometheusExternalUrl }}
+    {{- end }}
+    {{- if .Values.routePrefix }}
+    - --route-prefix={{ .Values.routePrefix }}
+    {{- end }}
+    {{- with .Values.extraApiArgs }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  resources:
+    {{- toYaml .Values.resources | nindent 4 }}
+  ports:
+    - name: http
+      containerPort: 9099
+  {{- if .Values.extraApiVolumeMounts }}
+  volumeMounts:
+    {{- with .Values.extraApiVolumeMounts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/pyrra/templates/_pod.tpl
+++ b/charts/pyrra/templates/_pod.tpl
@@ -1,0 +1,83 @@
+{{/*
+Container definition for the Pyrra operator (kubernetes mode).
+*/}}
+{{- define "pyrra.container.kubernetes" -}}
+- name: {{ .Chart.Name }}-kubernetes
+  securityContext:
+    {{- toYaml .Values.securityContext | nindent 4 }}
+  image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  args:
+    - kubernetes
+    {{- if .Values.genericRules.enabled }}
+    - --generic-rules
+    {{- end }}
+    {{- if and .Values.validatingWebhookConfiguration.enabled ($.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
+    - --disable-webhooks=false
+    {{- end }}
+    {{- if .Values.operatorMetricsAddress }}
+    - --metrics-addr={{ .Values.operatorMetricsAddress }}
+    {{- end }}
+    {{- if .Values.operator.leaderElection.enabled }}
+    - --enable-leader-election
+    - --leader-election-namespace={{ .Values.operator.leaderElection.namespace | default (include "pyrra.namespace" .) }}
+    {{- end }}
+    {{- with .Values.extraKubernetesArgs }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  resources:
+    {{- toYaml .Values.operator.resources | nindent 4 }}
+  {{- with .Values.operator.resizePolicy }}
+  resizePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.validatingWebhookConfiguration.enabled ($.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
+  volumeMounts:
+    - mountPath: /tmp/k8s-webhook-server/serving-certs
+      name: certs
+  {{- end }}
+  ports:
+    - name: op-metrics
+      containerPort: {{ include "pyrra.operatorMetricsPort" . }}
+    - name: webhooks
+      containerPort: 9443
+{{- end }}
+
+{{/*
+Container definition for the Pyrra API server.
+*/}}
+{{- define "pyrra.container.api" -}}
+- name: {{ .Chart.Name }}
+  securityContext:
+    {{- toYaml .Values.securityContext | nindent 4 }}
+  image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  args:
+    - api
+    - --prometheus-url={{ .Values.prometheusUrl }}
+    - --api-url=http://localhost:9444
+    {{- if .Values.prometheusExternalUrl }}
+    - --prometheus-external-url={{ .Values.prometheusExternalUrl }}
+    {{- end }}
+    {{- if .Values.routePrefix }}
+    - --route-prefix={{ .Values.routePrefix }}
+    {{- end }}
+    {{- with .Values.extraApiArgs }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  resources:
+    {{- toYaml .Values.resources | nindent 4 }}
+  {{- with .Values.resizePolicy }}
+  resizePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      containerPort: 9099
+  {{- if .Values.extraApiVolumeMounts }}
+  volumeMounts:
+    {{- with .Values.extraApiVolumeMounts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/pyrra/templates/deployment.yaml
+++ b/charts/pyrra/templates/deployment.yaml
@@ -27,70 +27,8 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}-kubernetes
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args:
-            - kubernetes
-            {{- if .Values.genericRules.enabled }}
-            - --generic-rules
-            {{- end }}
-            {{- if and .Values.validatingWebhookConfiguration.enabled ($.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
-            - --disable-webhooks=false
-            {{- end }}
-            {{- if .Values.operatorMetricsAddress }}
-            - --metrics-addr={{ .Values.operatorMetricsAddress }}
-            {{- end }}
-            {{- if .Values.operator.leaderElection.enabled }}
-            - --enable-leader-election
-            - --leader-election-namespace={{ .Values.operator.leaderElection.namespace | default (include "pyrra.namespace" .) }}
-            {{- end }}
-            {{- with .Values.extraKubernetesArgs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-          resources:
-            {{- toYaml .Values.operator.resources | nindent 12 }}
-          {{- if and .Values.validatingWebhookConfiguration.enabled ($.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
-          volumeMounts:
-          - mountPath: /tmp/k8s-webhook-server/serving-certs
-            name: certs
-          {{- end }}
-          ports:
-            - name: op-metrics
-              containerPort: {{ include "pyrra.operatorMetricsPort" . }}
-            - name: webhooks
-              containerPort: 9443
-        - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args:
-            - api
-            - --prometheus-url={{ .Values.prometheusUrl }}
-            - --api-url=http://localhost:9444
-            {{- if .Values.prometheusExternalUrl }}
-            - --prometheus-external-url={{ .Values.prometheusExternalUrl }}
-            {{- end }}
-            {{- if .Values.routePrefix }}
-            - --route-prefix={{ .Values.routePrefix }}
-            {{- end }}
-            {{- with .Values.extraApiArgs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-          ports:
-          - name: http
-            containerPort: 9099
-          {{- if .Values.extraApiVolumeMounts }}
-          volumeMounts:
-            {{- with .Values.extraApiVolumeMounts }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
+        {{- include "pyrra.container.kubernetes" . | nindent 8 }}
+        {{- include "pyrra.container.api" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -114,4 +52,3 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
-

--- a/charts/pyrra/templates/deployment.yaml
+++ b/charts/pyrra/templates/deployment.yaml
@@ -27,78 +27,8 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}-kubernetes
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args:
-            - kubernetes
-            {{- if .Values.genericRules.enabled }}
-            - --generic-rules
-            {{- end }}
-            {{- if and .Values.validatingWebhookConfiguration.enabled ($.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
-            - --disable-webhooks=false
-            {{- end }}
-            {{- if .Values.operatorMetricsAddress }}
-            - --metrics-addr={{ .Values.operatorMetricsAddress }}
-            {{- end }}
-            {{- if .Values.operator.leaderElection.enabled }}
-            - --enable-leader-election
-            - --leader-election-namespace={{ .Values.operator.leaderElection.namespace | default (include "pyrra.namespace" .) }}
-            {{- end }}
-            {{- with .Values.extraKubernetesArgs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-          resources:
-            {{- toYaml .Values.operator.resources | nindent 12 }}
-          {{- with .Values.operator.resizePolicy }}
-          resizePolicy:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- if and .Values.validatingWebhookConfiguration.enabled ($.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
-          volumeMounts:
-          - mountPath: /tmp/k8s-webhook-server/serving-certs
-            name: certs
-          {{- end }}
-          ports:
-            - name: op-metrics
-              containerPort: {{ include "pyrra.operatorMetricsPort" . }}
-            - name: webhooks
-              containerPort: 9443
-        - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args:
-            - api
-            - --prometheus-url={{ .Values.prometheusUrl }}
-            - --api-url=http://localhost:9444
-            {{- if .Values.prometheusExternalUrl }}
-            - --prometheus-external-url={{ .Values.prometheusExternalUrl }}
-            {{- end }}
-            {{- if .Values.routePrefix }}
-            - --route-prefix={{ .Values.routePrefix }}
-            {{- end }}
-            {{- with .Values.extraApiArgs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.resizePolicy }}
-          resizePolicy:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          ports:
-          - name: http
-            containerPort: 9099
-          {{- if .Values.extraApiVolumeMounts }}
-          volumeMounts:
-            {{- with .Values.extraApiVolumeMounts }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
+        {{- include "pyrra.container.kubernetes" . | nindent 8 }}
+        {{- include "pyrra.container.api" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -122,4 +52,3 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
-


### PR DESCRIPTION
This is the first step of https://github.com/pyrra-dev/helm-charts/issues/44.
It shifts each container definition into a template which can be reused in different other resources later.