### PR TITLE
feat(pyrra): add resizePolicy support for containers

### DIFF
--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pyrra
 # renovate: github=pyrra-dev/pyrra
 appVersion: v0.10.0
-version: 1.5.0
+version: 1.6.0
 description: SLO manager and alert generator
 sources:
   - https://github.com/pyrra-dev/pyrra

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -60,9 +60,10 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | nameOverride | string | `""` | overrides chart name |
 | namespaceOverride | string | `""` | Overrides the namespace for all resources (defaults to .Release.Namespace) |
 | nodeSelector | object | `{}` | node selector for scheduling server pod |
-| operator | object | `{"leaderElection":{"enabled":true,"namespace":""},"resources":{"limits":{"memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}}` | All settings related to the "operator" kubernetes container |
+| operator | object | `{"leaderElection":{"enabled":true,"namespace":""},"resizePolicy":[],"resources":{"limits":{"memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}}` | All settings related to the "operator" kubernetes container |
 | operator.leaderElection.enabled | bool | `true` | enables leader election for the operator (required when running multiple replicas) |
 | operator.leaderElection.namespace | string | `""` | namespace where the leader election lease resource will be created (defaults to release namespace) |
+| operator.resizePolicy | list | `[]` | resize policy for the operator container (requires Kubernetes 1.27+ with InPlacePodVerticalScaling feature gate) |
 | operator.resources | object | `{"limits":{"memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}` | resource limits and requests |
 | operatorMetricsAddress | string | `":8080"` | Address to expose operator metrics |
 | podAnnotations | object | `{}` | additional annotations for server pod |
@@ -72,6 +73,7 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | prometheusRule.labels | object | `{}` | Set labels that will be applied on all PrometheusRules (alerts) |
 | prometheusRule.pyrraReconciliationError.severity | string | `"warning"` | Set severity for PyrraReconciliationError alert |
 | prometheusUrl | string | `"http://prometheus-operated.monitoring.svc.cluster.local:9090"` | URL to prometheus instance with metrics |
+| resizePolicy | list | `[]` | resize policy for the server container (requires Kubernetes 1.27+ with InPlacePodVerticalScaling feature gate) |
 | resources | object | `{"limits":{"memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}` | resource limits and requests for server pod |
 | route | object | `{"main":{"additionalRules":[],"annotations":{},"apiVersion":"gateway.networking.k8s.io/v1","enabled":false,"filters":[],"hostnames":[],"httpsRedirect":false,"kind":"HTTPRoute","labels":{},"matches":[{"path":{"type":"PathPrefix","value":"/"}}],"parentRefs":[],"timeouts":{}}}` | Gateway API HTTPRoute configuration. Supports multiple named routes. |
 | route.main.additionalRules | list | `[]` | additional custom rules prepended to the route rules |

--- a/charts/pyrra/templates/deployment.yaml
+++ b/charts/pyrra/templates/deployment.yaml
@@ -52,6 +52,10 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.operator.resources | nindent 12 }}
+          {{- with .Values.operator.resizePolicy }}
+          resizePolicy:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if and .Values.validatingWebhookConfiguration.enabled ($.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
           volumeMounts:
           - mountPath: /tmp/k8s-webhook-server/serving-certs
@@ -82,6 +86,10 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.resizePolicy }}
+          resizePolicy:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
           - name: http
             containerPort: 9099

--- a/charts/pyrra/tests/deployment_test.yaml
+++ b/charts/pyrra/tests/deployment_test.yaml
@@ -101,3 +101,42 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --leader-election-namespace=monitoring
+
+  - it: should not render resizePolicy by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resizePolicy
+      - notExists:
+          path: spec.template.spec.containers[1].resizePolicy
+
+  - it: should render resizePolicy for server container when set
+    set:
+      resizePolicy:
+        - resourceName: cpu
+          restartPolicy: NotRequired
+        - resourceName: memory
+          restartPolicy: RestartContainer
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].resizePolicy
+          value:
+            - resourceName: cpu
+              restartPolicy: NotRequired
+            - resourceName: memory
+              restartPolicy: RestartContainer
+      - notExists:
+          path: spec.template.spec.containers[0].resizePolicy
+
+  - it: should render resizePolicy for operator container when set
+    set:
+      operator.resizePolicy:
+        - resourceName: cpu
+          restartPolicy: NotRequired
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy
+          value:
+            - resourceName: cpu
+              restartPolicy: NotRequired
+      - notExists:
+          path: spec.template.spec.containers[1].resizePolicy

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -143,6 +143,13 @@ resources:
     cpu: 10m
     memory: 128Mi
 
+# -- resize policy for the server container (requires Kubernetes 1.27+ with InPlacePodVerticalScaling feature gate)
+resizePolicy: []
+  # - resourceName: cpu
+  #   restartPolicy: NotRequired
+  # - resourceName: memory
+  #   restartPolicy: RestartContainer
+
 # -- All settings related to the "operator" kubernetes container
 operator:
   # -- resource limits and requests
@@ -152,6 +159,12 @@ operator:
     requests:
       cpu: 10m
       memory: 128Mi
+  # -- resize policy for the operator container (requires Kubernetes 1.27+ with InPlacePodVerticalScaling feature gate)
+  resizePolicy: []
+    # - resourceName: cpu
+    #   restartPolicy: NotRequired
+    # - resourceName: memory
+    #   restartPolicy: RestartContainer
   leaderElection:
     # -- enables leader election for the operator (required when running multiple replicas)
     enabled: true


### PR DESCRIPTION
## Summary

- Add optional `resizePolicy` field to both the operator and server containers in the Pyrra Deployment, enabling [in-place pod vertical scaling](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/) on Kubernetes 1.27+ with the `InPlacePodVerticalScaling` feature gate.
- Defaults to an empty list, so existing deployments render identically — opt-in only.
- Chart version bumped 1.5.0 → 1.6.0 per the established feat-PR convention.

## Example

```yaml
# Server container
resizePolicy:
  - resourceName: cpu
    restartPolicy: NotRequired
  - resourceName: memory
    restartPolicy: RestartContainer

# Operator container
operator:
  resizePolicy:
    - resourceName: cpu
      restartPolicy: NotRequired
```

## Test plan

- [x] `helm lint charts/pyrra` passes
- [x] `helm unittest charts/pyrra` — 82/82 tests pass, including 3 new tests:
  - `should not render resizePolicy by default`
  - `should render resizePolicy for server container when set`
  - `should render resizePolicy for operator container when set`
- [x] `helm template` with `resizePolicy` set renders the field on the correct container
- [x] `helm template` with defaults does not render `resizePolicy` (backwards compatible)
- [x] `README.md` regenerated via `helm-docs`