### PR TITLE
feat(chart): add podLabels for pod template labels

### DIFF
--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pyrra
 # renovate: github=pyrra-dev/pyrra
 appVersion: v0.10.0
-version: 1.7.1
+version: 1.8.0
 description: SLO manager and alert generator
 sources:
   - https://github.com/pyrra-dev/pyrra

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -66,7 +66,8 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | operator.resizePolicy | list | `[]` | resize policy for the operator container (requires Kubernetes 1.27+ with InPlacePodVerticalScaling feature gate) |
 | operator.resources | object | `{"limits":{"memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}` | resource limits and requests |
 | operatorMetricsAddress | string | `":8080"` | Address to expose operator metrics |
-| podAnnotations | object | `{}` | additional annotations for server pod |
+| podAnnotations | object | `{}` | additional annotations for pod |
+| podLabels | object | `{}` | additional labels for pod |
 | podSecurityContext | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | security context for pod |
 | prometheusExternalUrl | string | `""` | URL to public-facing prometheus UI in case it differs from prometheusUrl |
 | prometheusRule.enabled | bool | `false` | enables creation of PrometheusRules to monitor Pyrra |

--- a/charts/pyrra/templates/deployment.yaml
+++ b/charts/pyrra/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       {{- end }}
       labels:
         {{- include "pyrra.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/pyrra/tests/deployment_test.yaml
+++ b/charts/pyrra/tests/deployment_test.yaml
@@ -140,3 +140,57 @@ tests:
               restartPolicy: NotRequired
       - notExists:
           path: spec.template.spec.containers[1].resizePolicy
+
+  - it: should render no podLabels on the pod template by default
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels
+          value:
+            app.kubernetes.io/name: pyrra
+            app.kubernetes.io/instance: RELEASE-NAME
+
+  - it: should add podLabels to the pod template when set
+    set:
+      podLabels:
+        team: sre
+        environment: prod
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: sre
+      - equal:
+          path: spec.template.metadata.labels.environment
+          value: prod
+
+  - it: should keep selector free of podLabels
+    set:
+      podLabels:
+        team: sre
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: pyrra
+            app.kubernetes.io/instance: RELEASE-NAME
+      - notExists:
+          path: spec.selector.matchLabels.team
+
+  - it: should keep podLabels off the Deployment metadata
+    set:
+      podLabels:
+        team: sre
+    asserts:
+      - notExists:
+          path: metadata.labels.team
+
+  - it: should preserve selector labels on the pod template when podLabels is set
+    set:
+      podLabels:
+        team: sre
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: pyrra
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -46,8 +46,10 @@ serviceAccount:
   # -- If not set and create is true, a name is generated using the fullname template
   name: ""
 
-# -- additional annotations for server pod
+# -- additional annotations for pod
 podAnnotations: {}
+# -- additional labels for pod
+podLabels: {}
 # -- security context for pod
 podSecurityContext:
   runAsNonRoot: true


### PR DESCRIPTION
Mirror the existing podAnnotations value with a new podLabels knob that adds labels to spec.template.metadata.labels only. The Deployment selector (matchLabels) is intentionally left untouched to preserve Kubernetes' immutable selector contract.

Closes https://github.com/pyrra-dev/helm-charts/issues/21, supersedes https://github.com/pyrra-dev/helm-charts/pull/24