### PR TITLE
ci(workflows): replace checkov with zizmor

### DIFF
--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -1,5 +1,0 @@
-# https://github.com/bridgecrewio/checkov?tab=readme-ov-file#configuration-using-a-config-file
-skip-check:
-  - CKV_K8S_11 # you don't want to set CPU limits by default...
-  - CKV_K8S_21 # for tests, the namespace will always be "default"
-  - CKV_K8S_43 # digest should not be set by default in chart

--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -1,0 +1,6 @@
+---
+rules:
+  cache-poisoning:
+    disable: true
+  secrets-outside-env:
+    disable: true

--- a/.github/workflows/crd-sync-check.yaml
+++ b/.github/workflows/crd-sync-check.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Compare CRD against upstream appVersion
         run: |

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -119,6 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write # post PR summary comment
     steps:
       - name: Checkout Code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Run helm-unittest
@@ -122,6 +123,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Lint Code Base
@@ -133,10 +135,10 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_BASH: true
           VALIDATE_BASH_EXEC: true
-          VALIDATE_CHECKOV: true
           VALIDATE_EDITORCONFIG: true
           VALIDATE_ENV: true
           VALIDATE_GITHUB_ACTIONS: true
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: true
           VALIDATE_GITLEAKS: true
           VALIDATE_JSON: true
           VALIDATE_MARKDOWN: true

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -15,6 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Python

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Configure Git


### PR DESCRIPTION
super-linter v8.7.0's bundled checkov broadened scope to scan Helm templates and flags opinionated K8s policies that don't apply at chart level. Mirror prometheus-community: drop VALIDATE_CHECKOV in favour of VALIDATE_GITHUB_ACTIONS_ZIZMOR for GitHub Actions security audits, and add persist-credentials: false to all actions/checkout steps so the zizmor artipacked rule passes.

Unblocks #122.

<!-- markdownlint-disable-file MD041 -->
<!--
Thanks for contributing! Please fill in every section.
If you used an AI assistant to write the code, you are still responsible
for understanding it. So be ready to answer "why?" on every choice.
-->

## Summary

<!-- One or two sentences: what does this PR do and why? -->

## Related issue

<!-- Closes #N / Part of #N / N/A -->

## Checklist

- [x] I've signed my commits (`git commit -s`)
- [ ] I've bumped the chart version
- [ ] I've tested the changes locally inside my Kubernetes or OpenShift cluster
- [ ] I've added Helm chart tests in `charts/pyrra/ci/<feature>-values.yaml`
- [ ] I've added Helm unit-tests in `charts/pyrra/tests/<feature>-values.yaml`
- [ ] I've added docs to `charts/pyrra/README.md.gotmpl` (not the generated `README.md`)
- [ ] I've used an AI assistant to write the code

## Notes for reviewers

<!-- Anything reviewers should pay particular attention to. -->
