### PR TITLE
build(github-actions,lint-test): update k8s-version

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -17,13 +17,13 @@ jobs:
         # major and minor need manual adjustments
         include:
           # renovate: docker=kindest/node
-          - k8s-version: v1.32.11
-          # renovate: docker=kindest/node
           - k8s-version: v1.33.12
           # renovate: docker=kindest/node
           - k8s-version: v1.34.8
           # renovate: docker=kindest/node
           - k8s-version: v1.35.5
+          # renovate: docker=kindest/node
+          - k8s-version: v1.36.1
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Drop 1.31 testing and add 1.36 testing

<!-- markdownlint-disable-file MD041 -->
<!--
Thanks for contributing! Please fill in every section.
If you used an AI assistant to write the code, you are still responsible
for understanding it. So be ready to answer "why?" on every choice.
-->

## Summary

<!-- One or two sentences: what does this PR do and why? -->

## Related issue

<!-- Closes #N / Part of #N / N/A -->

## Checklist

- [x] I've signed my commits (`git commit -s`)
- [ ] I've bumped the chart version
- [ ] I've tested the changes locally inside my Kubernetes or OpenShift cluster
- [ ] I've added Helm chart tests in `charts/pyrra/ci/<feature>-values.yaml`
- [ ] I've added Helm unit-tests in `charts/pyrra/tests/<feature>-values.yaml`
- [ ] I've added docs to `charts/pyrra/README.md.gotmpl` (not the generated `README.md`)
- [ ] I've used an AI assistant to write the code

## Notes for reviewers

<!-- Anything reviewers should pay particular attention to. -->
