### PR TITLE
feat(pyrra): add extraObjects support for extra manifests

### DIFF
--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pyrra
 # renovate: github=pyrra-dev/pyrra
 appVersion: v0.10.1
-version: 1.8.1
+version: 1.9.0
 description: SLO manager and alert generator
 sources:
   - https://github.com/pyrra-dev/pyrra

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -44,6 +44,7 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | extraApiVolumeMounts | list | `[]` | Extra Volume Mounts for the container |
 | extraApiVolumes | list | `[]` | Extra Volumes for the pod |
 | extraKubernetesArgs | list | `[]` | Extra args for Pyrra's Kubernetes container |
+| extraObjects | list | `[]` | Extra Kubernetes objects to deploy with the chart. Supports a list (or map) of manifests, each entry either a YAML map or a templated string rendered with tpl. |
 | fullnameOverride | string | `""` | Overrides helm-generated chart fullname |
 | genericRules.enabled | bool | `false` | enables generate Pyrra generic recording rules. Pyrra generates metrics with the same name for each SLO. |
 | image.pullPolicy | string | `"IfNotPresent"` | Overrides pullpolicy |

--- a/charts/pyrra/ci/extra-objects-values.yaml
+++ b/charts/pyrra/ci/extra-objects-values.yaml
@@ -1,0 +1,14 @@
+extraObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: '{{ include "pyrra.fullname" . }}-extra'
+    data:
+      key: value
+  - |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: {{ include "pyrra.fullname" . }}-extra-secret
+    stringData:
+      key: value

--- a/charts/pyrra/templates/extra-objects.yaml
+++ b/charts/pyrra/templates/extra-objects.yaml
@@ -1,0 +1,15 @@
+{{- /* Normalize extraObjects to a list, easier to loop over */ -}}
+{{- $extraObjects := .Values.extraObjects | default (list) -}}
+
+{{- if kindIs "map" $extraObjects -}}
+  {{- $extraObjects = values $extraObjects -}}
+{{- end -}}
+
+{{- range $extraObjects }}
+---
+  {{- if kindIs "map" . }}
+    {{- tpl (toYaml .) $ | nindent 0 }}
+  {{- else if kindIs "string" . }}
+    {{- tpl . $ | nindent 0 }}
+  {{- end }}
+{{- end }}

--- a/charts/pyrra/tests/extra-objects_test.yaml
+++ b/charts/pyrra/tests/extra-objects_test.yaml
@@ -1,0 +1,83 @@
+suite: extra objects
+templates:
+  - templates/extra-objects.yaml
+tests:
+  - it: should not render any object by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a map manifest
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: test-cm
+          data:
+            key: value
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-cm
+
+  - it: should render a string manifest with tpl templating
+    set:
+      extraObjects:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: {{ include "pyrra.fullname" . }}-extra
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-pyrra-extra
+
+  - it: should render templated values inside a map manifest
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: '{{ include "pyrra.fullname" . }}-map'
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-pyrra-map
+
+  - it: should render multiple manifests
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: first
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: second
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should accept a map of manifests
+    set:
+      extraObjects:
+        my-configmap:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: from-map
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: from-map

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -235,3 +235,19 @@ dashboards:
   labelValue: "1"
   annotations: {}
   extraLabels: {}
+
+# -- Extra Kubernetes objects to deploy with the chart. Supports a list (or map) of manifests, each entry either a YAML map or a templated string rendered with tpl.
+extraObjects: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: '{{ include "pyrra.fullname" . }}-extra'
+  #   data:
+  #     key: value
+  # - |
+  #   apiVersion: v1
+  #   kind: Secret
+  #   metadata:
+  #     name: {{ include "pyrra.fullname" . }}-secret
+  #   stringData:
+  #     key: value


### PR DESCRIPTION
## Summary

Adds an extraObjects value to deploy additional Kubernetes objects alongside the chart, accepting a list or map of manifests where each entry is either a YAML map or a templated string rendered with tpl. Useful for shipping related resources with the release, such as an ExternalSecret, an extra PrometheusRule, or an Istio DestinationRule.

## Related issue

N/A

## Checklist

- [x] I've signed my commits (git commit -s)
- [x] I've bumped the chart version
- [ ] I've tested the changes locally inside my Kubernetes or OpenShift cluster
- [x] I've added Helm chart tests in charts/pyrra/ci/extra-objects-values.yaml
- [x] I've added Helm unit-tests in charts/pyrra/tests/extra-objects_test.yaml
- [x] I've added docs to charts/pyrra/README.md.gotmpl (not the generated README.md)
- [x] I've used an AI assistant to write the code

## Notes for reviewers

Docs are provided via helm-docs comments on extraObjects in values.yaml, which the existing chart.valuesSection directive in README.md.gotmpl renders into the values table.

Same pattern is widely used in community charts:

- [argo-cd extraObjects](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/templates/extra-manifests.yaml)
- [grafana extraObjects](https://github.com/grafana-community/helm-charts/blob/main/charts/grafana/)
- [kube-prometheus-stack extraManifests](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/extra-objects.yaml)
- [prom-label-proxy extraManifests PR](https://github.com/prometheus-community/helm-charts/pull/5889)

Known cosmetic warning: passing the map form emits a coalesce warning (skipped value for pyrra.extraObjects: Not a table) because the default is a list. Rendering is unaffected and the list form emits no warning.