### PR TITLE
feat(pyrra): add automountServiceAccountToken support

### DIFF
--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pyrra
 # renovate: github=pyrra-dev/pyrra
 appVersion: v0.10.1
-version: 1.9.0
+version: 1.10.0
 description: SLO manager and alert generator
 sources:
   - https://github.com/pyrra-dev/pyrra

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -34,6 +34,7 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | additionalLabels | object | `{}` |  |
+| automountServiceAccountToken | bool | `true` | Enabled by default because Pyrra's kubernetes container requires Kubernetes API access. |
 | dashboards.annotations | object | `{}` |  |
 | dashboards.enabled | bool | `false` | enables Grafana dashboards being deployed via configmap |
 | dashboards.extraLabels | object | `{}` |  |
@@ -98,6 +99,7 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | service.port | int | `9099` | service port for server |
 | service.type | string | `"ClusterIP"` | service type for server |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Disabled by default; the pod mounts the token explicitly via `automountServiceAccountToken`. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | If not set and create is true, a name is generated using the fullname template |
 | serviceMonitor.enabled | bool | `false` | enables servicemonitor for server monitoring |

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -34,7 +34,7 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | additionalLabels | object | `{}` |  |
-| automountServiceAccountToken | bool | `true` | Enabled by default because Pyrra's kubernetes container requires Kubernetes API access. |
+| automountServiceAccountToken | bool | `true` | Whether to automount the service account token in the pod. Enabled by default because Pyrra's kubernetes container requires Kubernetes API access. |
 | dashboards.annotations | object | `{}` |  |
 | dashboards.enabled | bool | `false` | enables Grafana dashboards being deployed via configmap |
 | dashboards.extraLabels | object | `{}` |  |
@@ -99,7 +99,7 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | service.port | int | `9099` | service port for server |
 | service.type | string | `"ClusterIP"` | service type for server |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
-| serviceAccount.automountServiceAccountToken | bool | `false` | Disabled by default; the pod mounts the token explicitly via `automountServiceAccountToken`. |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Whether pods running as this service account automatically mount the service account token. Disabled by default; the pod mounts the token explicitly via `automountServiceAccountToken`. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | If not set and create is true, a name is generated using the fullname template |
 | serviceMonitor.enabled | bool | `false` | enables servicemonitor for server monitoring |

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -34,7 +34,7 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | additionalLabels | object | `{}` |  |
-| automountServiceAccountToken | bool | `true` | Whether to automount the service account token in the pod. Enabled by default because Pyrra's kubernetes container requires Kubernetes API access. |
+| automountServiceAccountToken | bool | `true` | Whether to automount the service account token in the pod, enabled by default because Pyrra's kubernetes container requires Kubernetes API access. |
 | dashboards.annotations | object | `{}` |  |
 | dashboards.enabled | bool | `false` | enables Grafana dashboards being deployed via configmap |
 | dashboards.extraLabels | object | `{}` |  |
@@ -99,9 +99,9 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | service.port | int | `9099` | service port for server |
 | service.type | string | `"ClusterIP"` | service type for server |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
-| serviceAccount.automountServiceAccountToken | bool | `false` | Whether pods running as this service account automatically mount the service account token. Disabled by default; the pod mounts the token explicitly via `automountServiceAccountToken`. |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Whether pods running as this service account automatically mount the service account token, disabled by default; the pod mounts the token explicitly via `automountServiceAccountToken`. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
-| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| serviceAccount.name | string | `""` | The name of the service account to use, if not set and create is true, a name is generated using the fullname template |
 | serviceMonitor.enabled | bool | `false` | enables servicemonitor for server monitoring |
 | serviceMonitor.interval | string | `""` | Set interval for scraping metrics |
 | serviceMonitor.jobLabel | string | `""` | provides the possibility to override the jobName if needed |

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -91,17 +91,17 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | route.main.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | path/header match conditions |
 | route.main.parentRefs | list | `[]` | parentRefs defines which Gateways this route attaches to |
 | route.main.timeouts | object | `{}` | timeout configuration |
-| routePrefix | string | `""` | Must start with a slash and not end with a slash. |
+| routePrefix | string | `""` | URL under which the pyrra web server is serving content. this can be set when running behind a reverse proxy. Must start with a slash and not end with a slash. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | security context for each container |
 | service.annotations | object | `{}` | Annotations to add to the service |
-| service.nodePort | string | `""` | node port for HTTP, choose port between <30000-32767> |
+| service.nodePort | string | `""` | service nodePort to expose node port for HTTP, choose port between <30000-32767> |
 | service.operatorMetricsPort | int | `8080` | service port for operator metrics |
 | service.port | int | `9099` | service port for server |
 | service.type | string | `"ClusterIP"` | service type for server |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automountServiceAccountToken | bool | `false` | Whether pods running as this service account automatically mount the service account token. Disabled by default; the pod mounts the token explicitly via `automountServiceAccountToken`. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
-| serviceAccount.name | string | `""` | If not set and create is true, a name is generated using the fullname template |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | serviceMonitor.enabled | bool | `false` | enables servicemonitor for server monitoring |
 | serviceMonitor.interval | string | `""` | Set interval for scraping metrics |
 | serviceMonitor.jobLabel | string | `""` | provides the possibility to override the jobName if needed |

--- a/charts/pyrra/ci/automount-sa-token-values.yaml
+++ b/charts/pyrra/ci/automount-sa-token-values.yaml
@@ -1,3 +1,6 @@
+# Exercises the ServiceAccount-level automount toggle with an installable
+# combination. The pod-level false path breaks Pyrra's Kubernetes API access
+# by design, so it is covered by unit tests instead of a live install.
 serviceAccount:
   automountServiceAccountToken: true
-automountServiceAccountToken: false
+automountServiceAccountToken: true

--- a/charts/pyrra/ci/automount-sa-token-values.yaml
+++ b/charts/pyrra/ci/automount-sa-token-values.yaml
@@ -1,0 +1,3 @@
+serviceAccount:
+  automountServiceAccountToken: true
+automountServiceAccountToken: false

--- a/charts/pyrra/templates/deployment.yaml
+++ b/charts/pyrra/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "pyrra.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/pyrra/templates/serviceaccount.yaml
+++ b/charts/pyrra/templates/serviceaccount.yaml
@@ -11,4 +11,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/pyrra/tests/deployment_test.yaml
+++ b/charts/pyrra/tests/deployment_test.yaml
@@ -18,6 +18,20 @@ tests:
           path: spec.template.spec.containers[1].name
           value: pyrra
 
+  - it: should automount the service account token in the pod by default
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: true
+
+  - it: should not automount the service account token in the pod when disabled
+    set:
+      automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
   - it: should not include --generic-rules arg by default
     asserts:
       - notContains:

--- a/charts/pyrra/tests/serviceaccount_test.yaml
+++ b/charts/pyrra/tests/serviceaccount_test.yaml
@@ -15,3 +15,17 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should not automount the service account token by default
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: should automount the service account token when enabled
+    set:
+      serviceAccount.automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -42,15 +42,12 @@ serviceAccount:
   create: true
   # -- Annotations to add to the service account
   annotations: {}
-  # -- The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # -- The name of the service account to use, if not set and create is true, a name is generated using the fullname template
   name: ""
-  # -- Whether pods running as this service account automatically mount the service account token.
-  # Disabled by default; the pod mounts the token explicitly via `automountServiceAccountToken`.
+  # -- Whether pods running as this service account automatically mount the service account token, disabled by default; the pod mounts the token explicitly via `automountServiceAccountToken`.
   automountServiceAccountToken: false
 
-# -- Whether to automount the service account token in the pod.
-# Enabled by default because Pyrra's kubernetes container requires Kubernetes API access.
+# -- Whether to automount the service account token in the pod, enabled by default because Pyrra's kubernetes container requires Kubernetes API access.
 automountServiceAccountToken: true
 
 # -- additional annotations for pod

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -46,11 +46,11 @@ serviceAccount:
   # -- If not set and create is true, a name is generated using the fullname template
   name: ""
   # -- Whether pods running as this service account automatically mount the service account token.
-  # -- Disabled by default; the pod mounts the token explicitly via `automountServiceAccountToken`.
+  # Disabled by default; the pod mounts the token explicitly via `automountServiceAccountToken`.
   automountServiceAccountToken: false
 
 # -- Whether to automount the service account token in the pod.
-# -- Enabled by default because Pyrra's kubernetes container requires Kubernetes API access.
+# Enabled by default because Pyrra's kubernetes container requires Kubernetes API access.
 automountServiceAccountToken: true
 
 # -- additional annotations for pod

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -43,7 +43,7 @@ serviceAccount:
   # -- Annotations to add to the service account
   annotations: {}
   # -- The name of the service account to use.
-  # -- If not set and create is true, a name is generated using the fullname template
+  # If not set and create is true, a name is generated using the fullname template
   name: ""
   # -- Whether pods running as this service account automatically mount the service account token.
   # Disabled by default; the pod mounts the token explicitly via `automountServiceAccountToken`.
@@ -77,7 +77,7 @@ prometheusUrl: http://prometheus-operated.monitoring.svc.cluster.local:9090
 prometheusExternalUrl: ""
 
 # -- URL under which the pyrra web server is serving content. this can be set when running behind a reverse proxy.
-# -- Must start with a slash and not end with a slash.
+# Must start with a slash and not end with a slash.
 routePrefix: ""
 
 service:
@@ -88,7 +88,7 @@ service:
   # -- service port for server
   port: 9099
   # -- service nodePort to expose
-  # -- node port for HTTP, choose port between <30000-32767>
+  # node port for HTTP, choose port between <30000-32767>
   nodePort: ""
   # -- service port for operator metrics
   operatorMetricsPort: 8080

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -45,6 +45,13 @@ serviceAccount:
   # -- The name of the service account to use.
   # -- If not set and create is true, a name is generated using the fullname template
   name: ""
+  # -- Whether pods running as this service account automatically mount the service account token.
+  # -- Disabled by default; the pod mounts the token explicitly via `automountServiceAccountToken`.
+  automountServiceAccountToken: false
+
+# -- Whether to automount the service account token in the pod.
+# -- Enabled by default because Pyrra's kubernetes container requires Kubernetes API access.
+automountServiceAccountToken: true
 
 # -- additional annotations for pod
 podAnnotations: {}


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->

## Summary

Expose the automountServiceAccountToken option on both the ServiceAccount resource and the Deployment pod template. The ServiceAccount defaults to false so that pods reusing it do not implicitly receive API credentials, while the pod template defaults to true because the pyrra-kubernetes container requires Kubernetes API access to watch SLO objects and manage PrometheusRules. Since the pod level setting takes precedence over the ServiceAccount level setting, default installations keep working without any manual action.

## Related issue

Closes #46

## Checklist

- [x] I've signed my commits (`git commit -s`)
- [x] I've bumped the chart version
- [ ] I've tested the changes locally inside my Kubernetes or OpenShift cluster
- [x] I've added Helm chart tests in `charts/pyrra/ci/<feature>-values.yaml`
- [x] I've added Helm unit-tests in `charts/pyrra/tests/<feature>-values.yaml`
- [x] I've added docs to `charts/pyrra/README.md.gotmpl` (not the generated `README.md`)
- [x] I've used an AI assistant to write the code

## Notes for reviewers

The two new values are documented through helm-docs comments in values.yaml, so the values section of the generated README picks them up without changes to README.md.gotmpl itself.

This is shipped as a minor version bump. The only behavior change is that the ServiceAccount resource now sets automountServiceAccountToken to false. Workloads managed by this chart are unaffected because the pod template explicitly sets it to true, which takes precedence. Only external pods that reference this chart's ServiceAccount without declaring the field themselves would stop receiving a token, and blocking that implicit path is exactly the hardening this change is meant to provide. Users who run Pyrra without needing in cluster API access can now also set the pod level value to false.
