### PR TITLE
feat(pyrra): expose Prometheus, Grafana and alert-URL config

### DIFF
--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pyrra
 # renovate: github=pyrra-dev/pyrra
 appVersion: v0.10.1
-version: 1.10.0
+version: 1.11.0
 description: SLO manager and alert generator
 sources:
   - https://github.com/pyrra-dev/pyrra

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -19,6 +19,28 @@ helm install pyrra pyrra/pyrra
 Pyrra needs prometheus to work. You will need to specify that via prometheusUrl variable - default assumes you have default [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) deployed to "monitoring" namespace.
 Additionally, you (most likely) will need to specify prometheusExternalUrl with URL to public-facing prometheus UI (ingress or whatever you're using), otherwise pyrra links to graphs will be broken
 
+If Prometheus is behind authentication, set `prometheusBasicAuthUsername` and/or `prometheusBearerTokenPath`. Use `mimirOrgId` to query a specific tenant when Prometheus is fronted by Mimir.
+
+`prometheusBearerTokenPath` points at a file inside the container, so mount the token from a Secret with `extraApiVolumes`/`extraApiVolumeMounts`:
+
+```yaml
+prometheusBearerTokenPath: /etc/pyrra/prometheus/token
+extraApiVolumes:
+    - {name: prometheus-token, secret: {secretName: prometheus-token}}
+extraApiVolumeMounts:
+    - {name: prometheus-token, mountPath: /etc/pyrra/prometheus, readOnly: true}
+```
+
+There is no dedicated value for the HTTP basic-auth password: Pyrra only accepts it as a plain flag, which would land in the pod spec. If you need it, pass it through `extraApiArgs`.
+
+## Linking alerts back to Pyrra
+
+Set `externalUrl` to the public address of the Pyrra UI. The operator then adds a `pyrra_url` annotation to every generated alert, so an on-call responder can jump straight from a firing alert to the corresponding SLO.
+
+## Grafana Explore instead of Prometheus
+
+As an alternative to `prometheusExternalUrl`, set `grafanaExternalUrl` together with `grafanaExternalDatasourceId` to redirect graph links to Grafana Explore. `prometheusExternalUrl` and `grafanaExternalUrl` are mutually exclusive.
+
 ## Webhook Admissions Controller Validations (Optional)
 
 Pyrra can be configured to validate SLOs and SLO groups using a webhook admission controller. This is an optional feature that can be enabled by setting the `validatingWebhookConfiguration.enabled` value to `true`. The webhook admission controller will validate SLOs when they are created or updated.
@@ -41,6 +63,7 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | dashboards.label | string | `"grafana_dashboard"` | default value from the Grafana chart |
 | dashboards.labelValue | string | `"1"` | default value from the Grafana chart |
 | dashboards.namespace | string | `nil` |  |
+| externalUrl | string | `""` | Public-facing URL of the Pyrra UI. When set, the operator adds a pyrra_url annotation with a direct link to the SLO to every generated alert. |
 | extraApiArgs | list | `[]` | Extra args for Pyrra's API container |
 | extraApiVolumeMounts | list | `[]` | Extra Volume Mounts for the container |
 | extraApiVolumes | list | `[]` | Extra Volumes for the pod |
@@ -48,6 +71,9 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | extraObjects | list | `[]` | Extra Kubernetes objects to deploy with the chart. Supports a list (or map) of manifests, each entry either a YAML map or a templated string rendered with tpl. |
 | fullnameOverride | string | `""` | Overrides helm-generated chart fullname |
 | genericRules.enabled | bool | `false` | enables generate Pyrra generic recording rules. Pyrra generates metrics with the same name for each SLO. |
+| grafanaExternalDatasourceId | string | `""` | Grafana Explore Prometheus datasource ID. Required when grafanaExternalUrl is set. |
+| grafanaExternalOrgId | string | `""` | Grafana Explore organization ID. Pyrra defaults to "1" when unset. |
+| grafanaExternalUrl | string | `""` | URL to redirect users to the Grafana Explore page instead of Prometheus. Mutually exclusive with prometheusExternalUrl. |
 | image.pullPolicy | string | `"IfNotPresent"` | Overrides pullpolicy |
 | image.repository | string | `"ghcr.io/pyrra-dev/pyrra"` | Overrides the image repository |
 | image.tag | string | `""` | Overrides the image tag |
@@ -59,6 +85,7 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
+| mimirOrgId | string | `""` | Mimir tenant ID (X-Scope-OrgID) to send when querying Prometheus behind Mimir |
 | nameOverride | string | `""` | overrides chart name |
 | namespaceOverride | string | `""` | Overrides the namespace for all resources (defaults to .Release.Namespace) |
 | nodeSelector | object | `{}` | node selector for scheduling server pod |
@@ -71,6 +98,8 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | podAnnotations | object | `{}` | additional annotations for pod |
 | podLabels | object | `{}` | additional labels for pod |
 | podSecurityContext | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | security context for pod |
+| prometheusBasicAuthUsername | string | `""` | HTTP basic auth username for querying Prometheus |
+| prometheusBearerTokenPath | string | `""` | Path to a bearer token file for querying Prometheus. Mount the file via extraApiVolumes/extraApiVolumeMounts. For the basic auth password, use extraApiArgs, since Pyrra only accepts it as a plain flag value. |
 | prometheusExternalUrl | string | `""` | URL to public-facing prometheus UI in case it differs from prometheusUrl |
 | prometheusRule.enabled | bool | `false` | enables creation of PrometheusRules to monitor Pyrra |
 | prometheusRule.labels | object | `{}` | Set labels that will be applied on all PrometheusRules (alerts) |

--- a/charts/pyrra/README.md.gotmpl
+++ b/charts/pyrra/README.md.gotmpl
@@ -19,6 +19,28 @@ helm install pyrra pyrra/pyrra
 Pyrra needs prometheus to work. You will need to specify that via prometheusUrl variable - default assumes you have default [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) deployed to "monitoring" namespace.
 Additionally, you (most likely) will need to specify prometheusExternalUrl with URL to public-facing prometheus UI (ingress or whatever you're using), otherwise pyrra links to graphs will be broken
 
+If Prometheus is behind authentication, set `prometheusBasicAuthUsername` and/or `prometheusBearerTokenPath`. Use `mimirOrgId` to query a specific tenant when Prometheus is fronted by Mimir.
+
+`prometheusBearerTokenPath` points at a file inside the container, so mount the token from a Secret with `extraApiVolumes`/`extraApiVolumeMounts`:
+
+```yaml
+prometheusBearerTokenPath: /etc/pyrra/prometheus/token
+extraApiVolumes:
+    - {name: prometheus-token, secret: {secretName: prometheus-token}}
+extraApiVolumeMounts:
+    - {name: prometheus-token, mountPath: /etc/pyrra/prometheus, readOnly: true}
+```
+
+There is no dedicated value for the HTTP basic-auth password: Pyrra only accepts it as a plain flag, which would land in the pod spec. If you need it, pass it through `extraApiArgs`.
+
+## Linking alerts back to Pyrra
+
+Set `externalUrl` to the public address of the Pyrra UI. The operator then adds a `pyrra_url` annotation to every generated alert, so an on-call responder can jump straight from a firing alert to the corresponding SLO.
+
+## Grafana Explore instead of Prometheus
+
+As an alternative to `prometheusExternalUrl`, set `grafanaExternalUrl` together with `grafanaExternalDatasourceId` to redirect graph links to Grafana Explore. `prometheusExternalUrl` and `grafanaExternalUrl` are mutually exclusive.
+
 ## Webhook Admissions Controller Validations (Optional)
 
 Pyrra can be configured to validate SLOs and SLO groups using a webhook admission controller. This is an optional feature that can be enabled by setting the `validatingWebhookConfiguration.enabled` value to `true`. The webhook admission controller will validate SLOs when they are created or updated.

--- a/charts/pyrra/ci/api-config-values.yaml
+++ b/charts/pyrra/ci/api-config-values.yaml
@@ -1,0 +1,7 @@
+# Exercises the operator alert-link URL and the Prometheus-facing API config
+# (public UI redirect, basic-auth username, Mimir tenant). All of these are
+# boot-safe flags with no external dependency, so the release installs cleanly.
+externalUrl: https://pyrra.example.com
+prometheusExternalUrl: https://prometheus.example.com
+prometheusBasicAuthUsername: pyrra
+mimirOrgId: tenant-a

--- a/charts/pyrra/ci/grafana-explore-values.yaml
+++ b/charts/pyrra/ci/grafana-explore-values.yaml
@@ -1,0 +1,7 @@
+# Exercises the Grafana Explore redirect, which is mutually exclusive with
+# prometheusExternalUrl and only valid when URL and datasource ID are set
+# together. Kept in its own fixture so it never collides with the API config
+# fixture that sets prometheusExternalUrl.
+grafanaExternalUrl: https://grafana.example.com
+grafanaExternalDatasourceId: prometheus-uid
+grafanaExternalOrgId: "2"

--- a/charts/pyrra/templates/_pod.tpl
+++ b/charts/pyrra/templates/_pod.tpl
@@ -22,6 +22,9 @@ Container definition for the Pyrra operator (kubernetes mode).
     - --enable-leader-election
     - --leader-election-namespace={{ .Values.operator.leaderElection.namespace | default (include "pyrra.namespace" .) }}
     {{- end }}
+    {{- if .Values.externalUrl }}
+    - --external-url={{ .Values.externalUrl }}
+    {{- end }}
     {{- with .Values.extraKubernetesArgs }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -47,6 +50,15 @@ Container definition for the Pyrra operator (kubernetes mode).
 Container definition for the Pyrra API server.
 */}}
 {{- define "pyrra.container.api" -}}
+{{- if and .Values.prometheusExternalUrl .Values.grafanaExternalUrl }}
+{{- fail "pyrra: set only one of prometheusExternalUrl or grafanaExternalUrl, not both" }}
+{{- end }}
+{{- if and .Values.grafanaExternalUrl (not .Values.grafanaExternalDatasourceId) }}
+{{- fail "pyrra: grafanaExternalDatasourceId is required when grafanaExternalUrl is set" }}
+{{- end }}
+{{- if and .Values.grafanaExternalDatasourceId (not .Values.grafanaExternalUrl) }}
+{{- fail "pyrra: grafanaExternalDatasourceId requires grafanaExternalUrl to be set" }}
+{{- end -}}
 - name: {{ .Chart.Name }}
   securityContext:
     {{- toYaml .Values.securityContext | nindent 4 }}
@@ -58,6 +70,24 @@ Container definition for the Pyrra API server.
     - --api-url=http://localhost:9444
     {{- if .Values.prometheusExternalUrl }}
     - --prometheus-external-url={{ .Values.prometheusExternalUrl }}
+    {{- end }}
+    {{- if .Values.prometheusBasicAuthUsername }}
+    - --prometheus-basic-auth-username={{ .Values.prometheusBasicAuthUsername }}
+    {{- end }}
+    {{- if .Values.prometheusBearerTokenPath }}
+    - --prometheus-bearer-token-path={{ .Values.prometheusBearerTokenPath }}
+    {{- end }}
+    {{- if .Values.mimirOrgId }}
+    - --mimir-org-id={{ .Values.mimirOrgId }}
+    {{- end }}
+    {{- if .Values.grafanaExternalUrl }}
+    - --grafana-external-url={{ .Values.grafanaExternalUrl }}
+    {{- end }}
+    {{- if .Values.grafanaExternalOrgId }}
+    - --grafana-external-org-id={{ .Values.grafanaExternalOrgId }}
+    {{- end }}
+    {{- if .Values.grafanaExternalDatasourceId }}
+    - --grafana-external-datasource-id={{ .Values.grafanaExternalDatasourceId }}
     {{- end }}
     {{- if .Values.routePrefix }}
     - --route-prefix={{ .Values.routePrefix }}

--- a/charts/pyrra/tests/deployment_test.yaml
+++ b/charts/pyrra/tests/deployment_test.yaml
@@ -62,6 +62,117 @@ tests:
           path: spec.template.spec.containers[1].args
           content: --prometheus-external-url=https://prometheus.example.com
 
+  - it: should not include --external-url arg by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --external-url
+
+  - it: should include --external-url arg when externalUrl is set
+    set:
+      externalUrl: https://pyrra.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --external-url=https://pyrra.example.com
+
+  - it: should not include Prometheus auth or Grafana args by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[1].args
+          content: --prometheus-basic-auth-username=
+      - notContains:
+          path: spec.template.spec.containers[1].args
+          content: --prometheus-bearer-token-path=
+      - notContains:
+          path: spec.template.spec.containers[1].args
+          content: --mimir-org-id=
+      - notContains:
+          path: spec.template.spec.containers[1].args
+          content: --grafana-external-url=
+
+  - it: should include Prometheus auth args when set
+    set:
+      prometheusBasicAuthUsername: pyrra
+      prometheusBearerTokenPath: /var/run/secrets/token
+      mimirOrgId: tenant-a
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --prometheus-basic-auth-username=pyrra
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --prometheus-bearer-token-path=/var/run/secrets/token
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --mimir-org-id=tenant-a
+
+  - it: should mount a Prometheus bearer token from a secret alongside the flag
+    set:
+      prometheusBearerTokenPath: /etc/pyrra/prometheus/token
+      extraApiVolumes:
+        - name: prometheus-token
+          secret:
+            secretName: prometheus-token
+      extraApiVolumeMounts:
+        - name: prometheus-token
+          mountPath: /etc/pyrra/prometheus
+          readOnly: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --prometheus-bearer-token-path=/etc/pyrra/prometheus/token
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: prometheus-token
+            mountPath: /etc/pyrra/prometheus
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: prometheus-token
+            secret:
+              secretName: prometheus-token
+
+  - it: should include Grafana args when set
+    set:
+      grafanaExternalUrl: https://grafana.example.com
+      grafanaExternalOrgId: "2"
+      grafanaExternalDatasourceId: prom-ds
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --grafana-external-url=https://grafana.example.com
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --grafana-external-org-id=2
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --grafana-external-datasource-id=prom-ds
+
+  - it: should fail when both prometheusExternalUrl and grafanaExternalUrl are set
+    set:
+      prometheusExternalUrl: https://prometheus.example.com
+      grafanaExternalUrl: https://grafana.example.com
+    asserts:
+      - failedTemplate:
+          errorMessage: "pyrra: set only one of prometheusExternalUrl or grafanaExternalUrl, not both"
+
+  - it: should fail when grafanaExternalUrl is set without grafanaExternalDatasourceId
+    set:
+      grafanaExternalUrl: https://grafana.example.com
+    asserts:
+      - failedTemplate:
+          errorMessage: "pyrra: grafanaExternalDatasourceId is required when grafanaExternalUrl is set"
+
+  - it: should fail when grafanaExternalDatasourceId is set without grafanaExternalUrl
+    set:
+      grafanaExternalDatasourceId: prom-ds
+    asserts:
+      - failedTemplate:
+          errorMessage: "pyrra: grafanaExternalDatasourceId requires grafanaExternalUrl to be set"
+
   - it: should add extra api volumes
     set:
       extraApiVolumes:

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -72,10 +72,26 @@ securityContext:
 prometheusUrl: http://prometheus-operated.monitoring.svc.cluster.local:9090
 # -- URL to public-facing prometheus UI in case it differs from prometheusUrl
 prometheusExternalUrl: ""
+# -- HTTP basic auth username for querying Prometheus
+prometheusBasicAuthUsername: ""
+# -- Path to a bearer token file for querying Prometheus. Mount the file via extraApiVolumes/extraApiVolumeMounts. For the basic auth password, use extraApiArgs, since Pyrra only accepts it as a plain flag value.
+prometheusBearerTokenPath: ""
+# -- Mimir tenant ID (X-Scope-OrgID) to send when querying Prometheus behind Mimir
+mimirOrgId: ""
+
+# -- URL to redirect users to the Grafana Explore page instead of Prometheus. Mutually exclusive with prometheusExternalUrl.
+grafanaExternalUrl: ""
+# -- Grafana Explore organization ID. Pyrra defaults to "1" when unset.
+grafanaExternalOrgId: ""
+# -- Grafana Explore Prometheus datasource ID. Required when grafanaExternalUrl is set.
+grafanaExternalDatasourceId: ""
 
 # -- URL under which the pyrra web server is serving content. this can be set when running behind a reverse proxy.
 # Must start with a slash and not end with a slash.
 routePrefix: ""
+
+# -- Public-facing URL of the Pyrra UI. When set, the operator adds a pyrra_url annotation with a direct link to the SLO to every generated alert.
+externalUrl: ""
 
 service:
   # -- Annotations to add to the service


### PR DESCRIPTION
## Summary

Surfaces Pyrra's Prometheus- and Grafana-related CLI flags as first-class chart values, so common setups no longer need `extraApiArgs`/`extraKubernetesArgs`. Implements the `externalUrl` request from #118 and adds Grafana Explore integration plus authenticated / multi-tenant Prometheus access.

New values:

- `externalUrl` → operator `--external-url`: adds the `pyrra_url` annotation that deep-links each generated alert back to its SLO in the Pyrra UI
- `grafanaExternalUrl` / `grafanaExternalOrgId` / `grafanaExternalDatasourceId`: Grafana Explore as an alternative to `prometheusExternalUrl`
- `prometheusBasicAuthUsername` / `prometheusBearerTokenPath` / `mimirOrgId`: authenticated and multi-tenant Prometheus access

## Related issue

Closes #118

## Checklist

- [x] I've signed my commits (`git commit -s`)
- [x] I've bumped the chart version
- [ ] I've tested the changes locally inside my Kubernetes or OpenShift cluster
- [x] I've added Helm chart tests in `charts/pyrra/ci/<feature>-values.yaml`
- [x] I've added Helm unit-tests in `charts/pyrra/tests/<feature>-values.yaml`
- [x] I've added docs to `charts/pyrra/README.md.gotmpl` (not the generated `README.md`)
- [x] I've used an AI assistant to write the code

## Notes for reviewers

- **Container placement:** `externalUrl` maps to the operator container (`--external-url`), since the operator generates the alerting rules and writes the `pyrra_url` annotation. All Prometheus-query and Grafana flags map to the API container.
- **Verified against the pinned appVersion (`v0.10.1`), not `main`.** The `main` README documents `--mimir-tenant-ids`, but the released binary uses `--mimir-org-id` (singular); the chart passes the flag the pinned image actually accepts.
- **Template-time guards mirror Pyrra's boot checks.** Pyrra `os.Exit(1)`s on three invalid URL combinations; the chart now `fail`s at render time with a clear message instead, turning a crash-loop into a `helm install`/`ct` error:
  - `prometheusExternalUrl` together with `grafanaExternalUrl` (mutually exclusive)
  - `grafanaExternalUrl` without `grafanaExternalDatasourceId`
  - `grafanaExternalDatasourceId` without `grafanaExternalUrl`
- **Deliberate omissions:**
  - `--prometheus-basic-auth-password` is not a first-class value. Pyrra only accepts it as a plain flag, which would leak it into the pod spec and the Helm release secret; it stays reachable via `extraApiArgs`.
  - `--enable-prometheus-3-migration` is left out. It defaults to `true`, and a naive `{{- if }}` would silently swallow an explicit `false`; `extraApiArgs` covers the rare opt-out.
- **Testing:** verified with `helm template` (every new arg, all three guard failures, both `ci` fixtures), `helm lint`, and `helm-docs`; covered by `tests/deployment_test.yaml` and two `ct install` fixtures (`ci/api-config-values.yaml`, `ci/grafana-explore-values.yaml`).