### PR TITLE
feat(pyrra): Add ipFamily options for service (to enable DualStack if it needs)

### DIFF
--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pyrra
 # renovate: github=pyrra-dev/pyrra
 appVersion: v0.10.1
-version: 1.11.0
+version: 1.12.0
 description: SLO manager and alert generator
 sources:
   - https://github.com/pyrra-dev/pyrra

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -123,6 +123,8 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | routePrefix | string | `""` | URL under which the pyrra web server is serving content. this can be set when running behind a reverse proxy. Must start with a slash and not end with a slash. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | security context for each container |
 | service.annotations | object | `{}` | Annotations to add to the service |
+| service.ipFamilies | list | `[]` | Ordered list of IP families assigned to the service. Supported values: IPv4, IPv6. When using dual-stack, the first entry becomes the primary IP family. Leave empty to use the Kubernetes cluster default. |
+| service.ipFamilyPolicy | string | `""` | IP family policy for the service. Supported values: SingleStack, PreferDualStack, RequireDualStack. Leave empty to use the Kubernetes cluster default. |
 | service.nodePort | string | `""` | service nodePort to expose node port for HTTP, choose port between <30000-32767> |
 | service.operatorMetricsPort | int | `8080` | service port for operator metrics |
 | service.port | int | `9099` | service port for server |

--- a/charts/pyrra/templates/service.yaml
+++ b/charts/pyrra/templates/service.yaml
@@ -15,8 +15,9 @@ spec:
   {{- if .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
   {{- end }}
-  {{- if .Values.service.ipFamilies }}
-  ipFamilies: {{ .Values.service.ipFamilies | toYaml | nindent 2 }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 2 }}
   {{- end }}
   ports:
     - name: webhooks

--- a/charts/pyrra/templates/service.yaml
+++ b/charts/pyrra/templates/service.yaml
@@ -17,7 +17,7 @@ spec:
   {{- end }}
   {{- with .Values.service.ipFamilies }}
   ipFamilies:
-    {{- toYaml . | nindent 2 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   ports:
     - name: webhooks

--- a/charts/pyrra/templates/service.yaml
+++ b/charts/pyrra/templates/service.yaml
@@ -12,6 +12,12 @@ metadata:
     {{- include "pyrra.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies: {{ .Values.service.ipFamilies | toYaml | nindent 2 }}
+  {{- end }}
   ports:
     - name: webhooks
       port: 9443

--- a/charts/pyrra/tests/service_test.yaml
+++ b/charts/pyrra/tests/service_test.yaml
@@ -1,0 +1,35 @@
+suite: service
+templates:
+  - templates/service.yaml
+tests:
+  - it: should render a Service by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - isNull:
+          path: spec.ipFamilyPolicy
+      - isNull:
+          path: spec.ipFamilies
+
+  - it: should render configured IP family settings
+    set:
+      service:
+        ipFamilyPolicy: PreferDualStack
+        ipFamilies:
+          - IPv4
+          - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -105,6 +105,15 @@ service:
   nodePort: ""
   # -- service port for operator metrics
   operatorMetricsPort: 8080
+  # -- IP family policy for the service.
+  # Supported values: SingleStack, PreferDualStack, RequireDualStack.
+  # Leave empty to use the Kubernetes cluster default.
+  ipFamilyPolicy: ""
+  # -- Ordered list of IP families assigned to the service.
+  # Supported values: IPv4, IPv6.
+  # When using dual-stack, the first entry becomes the primary IP family.
+  # Leave empty to use the Kubernetes cluster default.
+  ipFamilies: []
 
 ingress:
   # -- enables ingress for server UI


### PR DESCRIPTION


<!-- markdownlint-disable-file MD041 -->
<!--
Thanks for contributing! Please fill in every section.
If you used an AI assistant to write the code, you are still responsible
for understanding it. So be ready to answer "why?" on every choice.
-->

## Summary

Parameters ipFamilyPolicy and ipFamilies for service were added to enable DualStack if it needs.

## Related issue

N/A

## Checklist

- [x] I've signed my commits (`git commit -s`)
- [x] I've bumped the chart version
- [x] I've tested the changes locally inside my Kubernetes or OpenShift cluster
- [ ] I've added Helm chart tests in `charts/pyrra/ci/<feature>-values.yaml`
- [x] I've added Helm unit-tests in `charts/pyrra/tests/<feature>-values.yaml`
- [ ] I've added docs to `charts/pyrra/README.md.gotmpl` (not the generated `README.md`)
- [ ] I've used an AI assistant to write the code

## Notes for reviewers

<!-- Anything reviewers should pay particular attention to. -->
