### PR TITLE
feat(pyrra): expose operator-side Mimir configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ trim_trailing_whitespace = true
 indent_size = 4
 indent_style = space
 
+[charts/*/README.md]
+indent_size = unset
+
 [*.{yml,yaml}]
 indent_size = 2
 indent_style = space

--- a/.github/testdata/mimir-stub.yaml
+++ b/.github/testdata/mimir-stub.yaml
@@ -1,0 +1,77 @@
+# Minimal stand-in for a Mimir API, deployed into the kind cluster before `ct install`.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mimir-stub
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mimir-stub
+  namespace: mimir-stub
+data:
+  default.conf: |
+    server {
+      listen 8080;
+      location /ready {
+        return 200 "ready\n";
+      }
+      location / {
+        return 404;
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mimir-stub
+  namespace: mimir-stub
+  labels:
+    app.kubernetes.io/name: mimir-stub
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir-stub
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir-stub
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          ports:
+            - name: http
+              containerPort: 8080
+          volumeMounts:
+            - name: conf
+              mountPath: /etc/nginx/conf.d
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+      volumes:
+        - name: conf
+          configMap:
+            name: mimir-stub
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mimir-stub
+  namespace: mimir-stub
+spec:
+  selector:
+    app.kubernetes.io/name: mimir-stub
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -115,6 +115,12 @@ jobs:
           helm install prometheus-operator-crds oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds
         if: steps.list-changed.outputs.changed == 'true'
 
+      - name: Deploy Mimir stub
+        run: |
+          kubectl apply -f .github/testdata/mimir-stub.yaml
+          kubectl --namespace mimir-stub rollout status deployment/mimir-stub --timeout=120s
+        if: steps.list-changed.outputs.changed == 'true'
+
       - name: Run chart-testing (install)
         run: ct install --config .github/linters/ct.yaml
 

--- a/charts/pyrra/Chart.yaml
+++ b/charts/pyrra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pyrra
 # renovate: github=pyrra-dev/pyrra
 appVersion: v0.10.1
-version: 1.12.0
+version: 1.13.0
 description: SLO manager and alert generator
 sources:
   - https://github.com/pyrra-dev/pyrra

--- a/charts/pyrra/README.md
+++ b/charts/pyrra/README.md
@@ -26,12 +26,51 @@ If Prometheus is behind authentication, set `prometheusBasicAuthUsername` and/or
 ```yaml
 prometheusBearerTokenPath: /etc/pyrra/prometheus/token
 extraApiVolumes:
-    - {name: prometheus-token, secret: {secretName: prometheus-token}}
+  - name: prometheus-token
+    secret:
+      secretName: prometheus-token
 extraApiVolumeMounts:
-    - {name: prometheus-token, mountPath: /etc/pyrra/prometheus, readOnly: true}
+  - name: prometheus-token
+    mountPath: /etc/pyrra/prometheus
+    readOnly: true
 ```
 
 There is no dedicated value for the HTTP basic-auth password: Pyrra only accepts it as a plain flag, which would land in the pod spec. If you need it, pass it through `extraApiArgs`.
+
+## Mimir
+
+There are two independent halves to running Pyrra against Mimir.
+
+**Querying** is the API container's job and needs nothing but a tenant: point `prometheusUrl` at the Mimir query endpoint and set `mimirOrgId` to send the `X-Scope-OrgID` header.
+
+**Provisioning rules** is the operator's job. Setting `mimir.url` switches it from creating `PrometheusRule` resources to writing recording rules directly to the Mimir Ruler. That single key gates the whole integration — there is no separate `enabled` flag, and any other `mimir.*` setting without a URL fails the render rather than being silently ignored.
+
+```yaml
+mimir:
+  url: http://mimir-nginx.mimir.svc:80
+  # standalone (default) or distributed — changes the endpoint Pyrra probes on startup
+  deploymentMode: standalone
+  # write alerting rules to the Ruler as well, not just recording rules
+  writeAlertingRules: true
+  orgId: my-tenant
+  basicAuth:
+    username: pyrra
+    existingSecret: mimir-credentials
+    existingSecretKey: password
+```
+
+`mimir.orgId` falls back to `mimirOrgId` when empty, since query and provisioning normally target the same tenant. Set it explicitly only if they differ.
+
+**Set a tenant unless you know Mimir runs without multi-tenancy.** Pyrra treats it as optional and simply omits the `X-Scope-OrgID` header when empty. Mimir defaults `-auth.multitenancy-enabled` to `true`, and its Ruler config endpoints (`POST`/`DELETE` on `<prefix>/config/v1/rules/{namespace}`) sit behind the auth middleware — so rule provisioning fails without the header. The endpoints Pyrra probes at startup do not: `/api/v1/status/buildinfo` is registered with auth explicitly disabled, and `/ready` is not registered through Mimir's API layer at all, so it never reaches the middleware that wraps those routes. The operator therefore starts up healthy in either deployment mode and only fails once it reconciles the first `ServiceLevelObjective`. If Mimir runs with `-auth.multitenancy-enabled=false` it uses the `-auth.no-auth-tenant` pseudo-tenant (`anonymous` by default) and leaving this empty is correct.
+
+### The basic-auth password
+
+Pyrra accepts the password only as a plain flag value and reads no environment variables, so the chart never writes it into the pod spec directly. It always goes through a Secret, mounted as an environment variable that Kubernetes expands into the `--mimir-basic-auth-password` argument. You choose where that Secret comes from:
+
+* **Bring your own** — set `basicAuth.existingSecret` (and `basicAuth.existingSecretKey` if the key differs from `mimir-basic-auth-password`). The password never passes through `values.yaml` or the Helm release, which is what you want with sealed-secrets, External Secrets Operator, or Vault.
+* **Let the chart render one** — set `basicAuth.password` and the chart creates `<fullname>-mimir-basic-auth`. Convenient for a quick test, but the value still lives in your values file and in the release, readable via `helm get values`. The pod gets a `checksum/mimir-basic-auth` annotation so rotating the password actually restarts the operator.
+
+The two are mutually exclusive; setting both fails the render rather than silently picking one.
 
 ## Linking alerts back to Pyrra
 
@@ -85,7 +124,16 @@ The dashboards can be deployed using a ConfigMap and get's automatically [reload
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
-| mimirOrgId | string | `""` | Mimir tenant ID (X-Scope-OrgID) to send when querying Prometheus behind Mimir |
+| mimir.basicAuth.existingSecret | string | `""` | Name of an existing Secret holding the Mimir basic auth password, so the value never passes through Helm at all. Mutually exclusive with `password`. |
+| mimir.basicAuth.existingSecretKey | string | `"mimir-basic-auth-password"` | Key inside `existingSecret` holding the password. Only applies to `existingSecret`; the chart-rendered Secret always uses the key `mimir-basic-auth-password`. |
+| mimir.basicAuth.password | string | `""` | HTTP basic auth password for the Mimir API. The chart renders it into a `<fullname>-mimir-basic-auth` Secret rather than into the pod spec, but the value still passes through `values.yaml` and the Helm release. Prefer `existingSecret` in production. |
+| mimir.basicAuth.username | string | `""` | HTTP basic auth username for the Mimir API |
+| mimir.deploymentMode | string | `"standalone"` | Mimir deployment mode. One of `standalone`, `distributed`. |
+| mimir.orgId | string | `""` | Mimir tenant ID (X-Scope-OrgID) the operator sends when provisioning rules. Falls back to `mimirOrgId` when empty, since query and provisioning usually target the same tenant. |
+| mimir.prometheusPrefix | string | `"prometheus"` | Prefix of the Prometheus API in Mimir |
+| mimir.url | string | `""` | URL to the Mimir API. When set, the operator provisions recording rules via the Mimir Ruler instead of creating PrometheusRule resources. This single key gates the whole Mimir integration — there is no separate `enabled` flag. Note that Pyrra checks the connection on startup and exits if Mimir is unreachable, so the operator will CrashLoopBackOff on a wrong URL. |
+| mimir.writeAlertingRules | bool | `false` | Provision alerting rules to the Mimir Ruler as well, in addition to recording rules |
+| mimirOrgId | string | `""` | Mimir tenant ID (X-Scope-OrgID) the API container sends when querying Prometheus behind Mimir |
 | nameOverride | string | `""` | overrides chart name |
 | namespaceOverride | string | `""` | Overrides the namespace for all resources (defaults to .Release.Namespace) |
 | nodeSelector | object | `{}` | node selector for scheduling server pod |

--- a/charts/pyrra/README.md.gotmpl
+++ b/charts/pyrra/README.md.gotmpl
@@ -26,12 +26,51 @@ If Prometheus is behind authentication, set `prometheusBasicAuthUsername` and/or
 ```yaml
 prometheusBearerTokenPath: /etc/pyrra/prometheus/token
 extraApiVolumes:
-    - {name: prometheus-token, secret: {secretName: prometheus-token}}
+  - name: prometheus-token
+    secret:
+      secretName: prometheus-token
 extraApiVolumeMounts:
-    - {name: prometheus-token, mountPath: /etc/pyrra/prometheus, readOnly: true}
+  - name: prometheus-token
+    mountPath: /etc/pyrra/prometheus
+    readOnly: true
 ```
 
 There is no dedicated value for the HTTP basic-auth password: Pyrra only accepts it as a plain flag, which would land in the pod spec. If you need it, pass it through `extraApiArgs`.
+
+## Mimir
+
+There are two independent halves to running Pyrra against Mimir.
+
+**Querying** is the API container's job and needs nothing but a tenant: point `prometheusUrl` at the Mimir query endpoint and set `mimirOrgId` to send the `X-Scope-OrgID` header.
+
+**Provisioning rules** is the operator's job. Setting `mimir.url` switches it from creating `PrometheusRule` resources to writing recording rules directly to the Mimir Ruler. That single key gates the whole integration — there is no separate `enabled` flag, and any other `mimir.*` setting without a URL fails the render rather than being silently ignored.
+
+```yaml
+mimir:
+  url: http://mimir-nginx.mimir.svc:80
+  # standalone (default) or distributed — changes the endpoint Pyrra probes on startup
+  deploymentMode: standalone
+  # write alerting rules to the Ruler as well, not just recording rules
+  writeAlertingRules: true
+  orgId: my-tenant
+  basicAuth:
+    username: pyrra
+    existingSecret: mimir-credentials
+    existingSecretKey: password
+```
+
+`mimir.orgId` falls back to `mimirOrgId` when empty, since query and provisioning normally target the same tenant. Set it explicitly only if they differ.
+
+**Set a tenant unless you know Mimir runs without multi-tenancy.** Pyrra treats it as optional and simply omits the `X-Scope-OrgID` header when empty. Mimir defaults `-auth.multitenancy-enabled` to `true`, and its Ruler config endpoints (`POST`/`DELETE` on `<prefix>/config/v1/rules/{namespace}`) sit behind the auth middleware — so rule provisioning fails without the header. The endpoints Pyrra probes at startup do not: `/api/v1/status/buildinfo` is registered with auth explicitly disabled, and `/ready` is not registered through Mimir's API layer at all, so it never reaches the middleware that wraps those routes. The operator therefore starts up healthy in either deployment mode and only fails once it reconciles the first `ServiceLevelObjective`. If Mimir runs with `-auth.multitenancy-enabled=false` it uses the `-auth.no-auth-tenant` pseudo-tenant (`anonymous` by default) and leaving this empty is correct.
+
+### The basic-auth password
+
+Pyrra accepts the password only as a plain flag value and reads no environment variables, so the chart never writes it into the pod spec directly. It always goes through a Secret, mounted as an environment variable that Kubernetes expands into the `--mimir-basic-auth-password` argument. You choose where that Secret comes from:
+
+* **Bring your own** — set `basicAuth.existingSecret` (and `basicAuth.existingSecretKey` if the key differs from `mimir-basic-auth-password`). The password never passes through `values.yaml` or the Helm release, which is what you want with sealed-secrets, External Secrets Operator, or Vault.
+* **Let the chart render one** — set `basicAuth.password` and the chart creates `<fullname>-mimir-basic-auth`. Convenient for a quick test, but the value still lives in your values file and in the release, readable via `helm get values`. The pod gets a `checksum/mimir-basic-auth` annotation so rotating the password actually restarts the operator.
+
+The two are mutually exclusive; setting both fails the render rather than silently picking one.
 
 ## Linking alerts back to Pyrra
 

--- a/charts/pyrra/ci/mimir-chart-secret-values.yaml
+++ b/charts/pyrra/ci/mimir-chart-secret-values.yaml
@@ -1,0 +1,7 @@
+mimir:
+  url: http://mimir-stub.mimir-stub.svc:8080
+  orgId: ci-tenant
+  basicAuth:
+    username: ci
+    # dummy credential for CI only
+    password: not-a-real-password

--- a/charts/pyrra/ci/mimir-values.yaml
+++ b/charts/pyrra/ci/mimir-values.yaml
@@ -1,0 +1,19 @@
+mimir:
+  url: http://mimir-stub.mimir-stub.svc:8080
+  prometheusPrefix: prometheus
+  deploymentMode: standalone
+  writeAlertingRules: true
+  orgId: ci-tenant
+  basicAuth:
+    username: ci
+    existingSecret: mimir-stub-auth
+    existingSecretKey: password
+
+extraObjects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: mimir-stub-auth
+    stringData:
+      # dummy credential for CI only
+      password: not-a-real-password

--- a/charts/pyrra/templates/_helpers.tpl
+++ b/charts/pyrra/templates/_helpers.tpl
@@ -78,3 +78,42 @@ Operator metrics port
 {{- define "pyrra.operatorMetricsPort" -}}
 {{ (split ":" .Values.operatorMetricsAddress)._1 }}
 {{- end }}
+
+{{/*
+Whether the operator needs a Mimir basic auth password from a Secret at all.
+*/}}
+{{- define "pyrra.mimirBasicAuthEnabled" -}}
+{{- if and .Values.mimir.url (or .Values.mimir.basicAuth.password .Values.mimir.basicAuth.existingSecret) -}}true{{- end -}}
+{{- end }}
+
+{{/*
+Whether this chart renders the Mimir basic auth Secret itself, as opposed to the
+user bringing their own via existingSecret.
+*/}}
+{{- define "pyrra.mimirBasicAuthChartManaged" -}}
+{{- if and .Values.mimir.url .Values.mimir.basicAuth.password (not .Values.mimir.basicAuth.existingSecret) -}}true{{- end -}}
+{{- end }}
+
+{{/*
+Name of the Secret holding the Mimir basic auth password: the user-provided
+existingSecret when set, otherwise the one this chart renders.
+*/}}
+{{- define "pyrra.mimirBasicAuthSecretName" -}}
+{{- if .Values.mimir.basicAuth.existingSecret -}}
+{{- .Values.mimir.basicAuth.existingSecret -}}
+{{- else -}}
+{{ include "pyrra.fullname" . }}-mimir-basic-auth
+{{- end -}}
+{{- end }}
+
+{{/*
+Key inside that Secret. existingSecretKey only applies to a user-provided Secret;
+the chart-rendered one always uses a fixed key.
+*/}}
+{{- define "pyrra.mimirBasicAuthSecretKey" -}}
+{{- if .Values.mimir.basicAuth.existingSecret -}}
+{{- .Values.mimir.basicAuth.existingSecretKey | default "mimir-basic-auth-password" -}}
+{{- else -}}
+mimir-basic-auth-password
+{{- end -}}
+{{- end }}

--- a/charts/pyrra/templates/_pod.tpl
+++ b/charts/pyrra/templates/_pod.tpl
@@ -2,6 +2,17 @@
 Container definition for the Pyrra operator (kubernetes mode).
 */}}
 {{- define "pyrra.container.kubernetes" -}}
+{{- $mimir := .Values.mimir -}}
+{{- $mimirAuth := $mimir.basicAuth -}}
+{{- if and $mimirAuth.password $mimirAuth.existingSecret }}
+{{- fail "pyrra: mimir.basicAuth.password and mimir.basicAuth.existingSecret are mutually exclusive" }}
+{{- end }}
+{{- if and (not $mimir.url) (or $mimirAuth.username $mimirAuth.password $mimirAuth.existingSecret $mimir.writeAlertingRules) }}
+{{- fail "pyrra: mimir.* is configured but mimir.url is empty, so the whole Mimir integration stays off" }}
+{{- end }}
+{{- if and $mimir.url (not (has $mimir.deploymentMode (list "standalone" "distributed"))) }}
+{{- fail (printf "pyrra: mimir.deploymentMode must be either standalone or distributed, got %q" $mimir.deploymentMode) }}
+{{- end }}
 - name: {{ .Chart.Name }}-kubernetes
   securityContext:
     {{- toYaml .Values.securityContext | nindent 4 }}
@@ -25,9 +36,34 @@ Container definition for the Pyrra operator (kubernetes mode).
     {{- if .Values.externalUrl }}
     - --external-url={{ .Values.externalUrl }}
     {{- end }}
+    {{- if $mimir.url }}
+    - --mimir-url={{ $mimir.url }}
+    - --mimir-prometheus-prefix={{ $mimir.prometheusPrefix }}
+    - --mimir-deployment-mode={{ $mimir.deploymentMode }}
+    {{- if $mimir.writeAlertingRules }}
+    - --mimir-write-alerting-rules
+    {{- end }}
+    {{- with ($mimir.orgId | default .Values.mimirOrgId) }}
+    - --mimir-org-id={{ . }}
+    {{- end }}
+    {{- with $mimirAuth.username }}
+    - --mimir-basic-auth-username={{ . }}
+    {{- end }}
+    {{- if include "pyrra.mimirBasicAuthEnabled" . }}
+    - --mimir-basic-auth-password=$(PYRRA_MIMIR_BASIC_AUTH_PASSWORD)
+    {{- end }}
+    {{- end }}
     {{- with .Values.extraKubernetesArgs }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- if include "pyrra.mimirBasicAuthEnabled" . }}
+  env:
+    - name: PYRRA_MIMIR_BASIC_AUTH_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "pyrra.mimirBasicAuthSecretName" . }}
+          key: {{ include "pyrra.mimirBasicAuthSecretKey" . }}
+  {{- end }}
   resources:
     {{- toYaml .Values.operator.resources | nindent 4 }}
   {{- with .Values.operator.resizePolicy }}

--- a/charts/pyrra/templates/deployment.yaml
+++ b/charts/pyrra/templates/deployment.yaml
@@ -12,9 +12,14 @@ spec:
       {{- include "pyrra.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- if or .Values.podAnnotations (include "pyrra.mimirBasicAuthChartManaged" .) }}
       annotations:
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if include "pyrra.mimirBasicAuthChartManaged" . }}
+        checksum/mimir-basic-auth: {{ .Values.mimir.basicAuth.password | sha256sum }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "pyrra.selectorLabels" . | nindent 8 }}

--- a/charts/pyrra/templates/mimir-secret.yaml
+++ b/charts/pyrra/templates/mimir-secret.yaml
@@ -1,0 +1,12 @@
+{{- if include "pyrra.mimirBasicAuthChartManaged" . -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pyrra.fullname" . }}-mimir-basic-auth
+  namespace: {{ include "pyrra.namespace" . }}
+  labels:
+    {{- include "pyrra.labels" . | nindent 4 }}
+stringData:
+  mimir-basic-auth-password: {{ .Values.mimir.basicAuth.password | quote }}
+{{- end -}}

--- a/charts/pyrra/tests/mimir-secret_test.yaml
+++ b/charts/pyrra/tests/mimir-secret_test.yaml
@@ -1,0 +1,58 @@
+suite: mimir basic auth secret
+templates:
+  - templates/mimir-secret.yaml
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when Mimir is enabled without basic auth
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render the password into a Secret instead of the pod spec
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.basicAuth.password: s3cr3t
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-pyrra-mimir-basic-auth
+      - equal:
+          path: stringData.mimir-basic-auth-password
+          value: s3cr3t
+
+  - it: should land in the overridden namespace
+    set:
+      namespaceOverride: pyrra-system
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.basicAuth.password: s3cr3t
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: pyrra-system
+
+  - it: should not render when the user brings their own Secret
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.basicAuth.existingSecret: mimir-auth
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should keep a numeric-looking password a string
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.basicAuth.password: "12345678"
+    asserts:
+      - equal:
+          path: stringData.mimir-basic-auth-password
+          value: "12345678"

--- a/charts/pyrra/tests/mimir_test.yaml
+++ b/charts/pyrra/tests/mimir_test.yaml
@@ -1,0 +1,228 @@
+suite: mimir
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: should not add any Mimir arg to the operator by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-url=
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-prometheus-prefix=prometheus
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-deployment-mode=standalone
+      - isNull:
+          path: spec.template.spec.containers[0].env
+
+  - it: should render the Mimir flags on the operator when a url is set
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-url=http://mimir.mimir.svc:8080
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-prometheus-prefix=prometheus
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-deployment-mode=standalone
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-write-alerting-rules
+
+  - it: should not leak Mimir flags into the API container
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.basicAuth.username: user
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[1].args
+          content: --mimir-url=http://mimir.mimir.svc:8080
+      - notContains:
+          path: spec.template.spec.containers[1].args
+          content: --mimir-basic-auth-username=user
+
+  - it: should honour prometheusPrefix, deploymentMode and writeAlertingRules
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.prometheusPrefix: prom
+      mimir.deploymentMode: distributed
+      mimir.writeAlertingRules: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-prometheus-prefix=prom
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-deployment-mode=distributed
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-write-alerting-rules
+
+  - it: should send the operator org id when set explicitly
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.orgId: tenant-a
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-org-id=tenant-a
+
+  - it: should fall back to mimirOrgId for the operator org id
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimirOrgId: tenant-b
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-org-id=tenant-b
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --mimir-org-id=tenant-b
+
+  - it: should prefer mimir.orgId over mimirOrgId for the operator only
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.orgId: tenant-a
+      mimirOrgId: tenant-b
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-org-id=tenant-a
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --mimir-org-id=tenant-b
+
+  - it: should send no org id when neither is set
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-org-id=
+
+  - it: should never put a plaintext password into the pod spec
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.basicAuth.username: user
+      mimir.basicAuth.password: s3cr3t
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-basic-auth-username=user
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-basic-auth-password=$(PYRRA_MIMIR_BASIC_AUTH_PASSWORD)
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-basic-auth-password=s3cr3t
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PYRRA_MIMIR_BASIC_AUTH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-pyrra-mimir-basic-auth
+                key: mimir-basic-auth-password
+
+  - it: should roll the pod when the chart-managed password changes
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.basicAuth.password: s3cr3t
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/mimir-basic-auth"]
+
+  - it: should not add a checksum annotation when the user brings their own secret
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.basicAuth.existingSecret: mimir-auth
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations["checksum/mimir-basic-auth"]
+
+  - it: should ignore existingSecretKey for the chart-rendered secret
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.basicAuth.password: s3cr3t
+      mimir.basicAuth.existingSecretKey: ignored-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PYRRA_MIMIR_BASIC_AUTH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-pyrra-mimir-basic-auth
+                key: mimir-basic-auth-password
+
+  - it: should inject an existing secret via an env var instead of a literal arg
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.basicAuth.username: user
+      mimir.basicAuth.existingSecret: mimir-auth
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --mimir-basic-auth-password=$(PYRRA_MIMIR_BASIC_AUTH_PASSWORD)
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PYRRA_MIMIR_BASIC_AUTH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: mimir-auth
+                key: mimir-basic-auth-password
+
+  - it: should honour a custom existingSecretKey
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.basicAuth.existingSecret: mimir-auth
+      mimir.basicAuth.existingSecretKey: mimir-password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PYRRA_MIMIR_BASIC_AUTH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: mimir-auth
+                key: mimir-password
+
+  - it: should keep the Mimir flags overridable through extraKubernetesArgs
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      extraKubernetesArgs:
+        - --mimir-deployment-mode=distributed
+    asserts:
+      # the user's arg must come last so kong's last-wins behaviour honours it
+      - equal:
+          path: spec.template.spec.containers[0].args[-1]
+          value: --mimir-deployment-mode=distributed
+
+  - it: should fail when both a plaintext password and an existingSecret are set
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.basicAuth.password: s3cr3t
+      mimir.basicAuth.existingSecret: mimir-auth
+    asserts:
+      - failedTemplate:
+          errorMessage: "pyrra: mimir.basicAuth.password and mimir.basicAuth.existingSecret are mutually exclusive"
+
+  - it: should fail when Mimir settings are given without a url
+    set:
+      mimir.basicAuth.username: user
+    asserts:
+      - failedTemplate:
+          errorMessage: "pyrra: mimir.* is configured but mimir.url is empty, so the whole Mimir integration stays off"
+
+  - it: should fail on an unsupported deployment mode
+    set:
+      mimir.url: http://mimir.mimir.svc:8080
+      mimir.deploymentMode: monolithic
+    asserts:
+      - failedTemplate:
+          errorMessage: 'pyrra: mimir.deploymentMode must be either standalone or distributed, got "monolithic"'

--- a/charts/pyrra/values.yaml
+++ b/charts/pyrra/values.yaml
@@ -76,8 +76,37 @@ prometheusExternalUrl: ""
 prometheusBasicAuthUsername: ""
 # -- Path to a bearer token file for querying Prometheus. Mount the file via extraApiVolumes/extraApiVolumeMounts. For the basic auth password, use extraApiArgs, since Pyrra only accepts it as a plain flag value.
 prometheusBearerTokenPath: ""
-# -- Mimir tenant ID (X-Scope-OrgID) to send when querying Prometheus behind Mimir
+# -- Mimir tenant ID (X-Scope-OrgID) the API container sends when querying Prometheus behind Mimir
 mimirOrgId: ""
+
+mimir:
+  # -- URL to the Mimir API. When set, the operator provisions recording rules via the Mimir Ruler
+  # instead of creating PrometheusRule resources. This single key gates the whole Mimir integration —
+  # there is no separate `enabled` flag. Note that Pyrra checks the connection on startup and exits
+  # if Mimir is unreachable, so the operator will CrashLoopBackOff on a wrong URL.
+  url: ""
+  # -- Prefix of the Prometheus API in Mimir
+  prometheusPrefix: prometheus
+  # -- Mimir deployment mode. One of `standalone`, `distributed`.
+  deploymentMode: standalone
+  # -- Provision alerting rules to the Mimir Ruler as well, in addition to recording rules
+  writeAlertingRules: false
+  # -- Mimir tenant ID (X-Scope-OrgID) the operator sends when provisioning rules. Falls back to
+  # `mimirOrgId` when empty, since query and provisioning usually target the same tenant.
+  orgId: ""
+  basicAuth:
+    # -- HTTP basic auth username for the Mimir API
+    username: ""
+    # -- HTTP basic auth password for the Mimir API. The chart renders it into a
+    # `<fullname>-mimir-basic-auth` Secret rather than into the pod spec, but the value still passes
+    # through `values.yaml` and the Helm release. Prefer `existingSecret` in production.
+    password: ""
+    # -- Name of an existing Secret holding the Mimir basic auth password, so the value never passes
+    # through Helm at all. Mutually exclusive with `password`.
+    existingSecret: ""
+    # -- Key inside `existingSecret` holding the password. Only applies to `existingSecret`; the
+    # chart-rendered Secret always uses the key `mimir-basic-auth-password`.
+    existingSecretKey: mimir-basic-auth-password
 
 # -- URL to redirect users to the Grafana Explore page instead of Prometheus. Mutually exclusive with prometheusExternalUrl.
 grafanaExternalUrl: ""


### PR DESCRIPTION
Pyrra's kubernetes subcommand can provision recording and alerting rules via the Mimir Ruler instead of creating PrometheusRule resources, but none of those flags were reachable from the chart - only the API container's --mimir-org-id was. Add a mimir.* block covering --mimir-url, --mimir-prometheus-prefix, --mimir-deployment-mode, --mimir-write-alerting-rules, --mimir-org-id and basic auth. It is gated on mimir.url alone, matching how Pyrra itself gates the
integration, and mimir.orgId falls back to mimirOrgId since query and provisioning normally target the same tenant.

The basic auth password never enters the pod spec. Pyrra parses with kong without DefaultEnvars and accepts the password only as a plain flag value, so the chart mounts it from a Secret as an environment variable and lets Kubernetes expand it into the argument. Either bring your own Secret via existingSecret, or let the chart render <fullname>-mimir-basic-auth from mimir.basicAuth.password. The two are mutually exclusive, and a chart-managed password gets a pod checksum annotation so rotating it restarts the operator.

The render fails fast on configuration that would otherwise be silently ignored: mimir.* without a url, both password variants at once, and a deploymentMode outside standalone/distributed. The Mimir flags render before extraKubernetesArgs so users can still override them.

Closes https://github.com/pyrra-dev/helm-charts/issues/22

<!-- markdownlint-disable-file MD041 -->
<!--
Thanks for contributing! Please fill in every section.
If you used an AI assistant to write the code, you are still responsible
for understanding it. So be ready to answer "why?" on every choice.
-->

## Summary

<!-- One or two sentences: what does this PR do and why? -->

## Related issue

<!-- Closes #N / Part of #N / N/A -->

## Checklist

- [x] I've signed my commits (`git commit -s`)
- [x] I've bumped the chart version
- [x] I've tested the changes locally inside my Kubernetes or OpenShift cluster
- [x] I've added Helm chart tests in `charts/pyrra/ci/<feature>-values.yaml`
- [x] I've added Helm unit-tests in `charts/pyrra/tests/<feature>-values.yaml`
- [x] I've added docs to `charts/pyrra/README.md.gotmpl` (not the generated `README.md`)
- [x] I've used an AI assistant to write the code

## Notes for reviewers

<!-- Anything reviewers should pay particular attention to. -->
